### PR TITLE
Switched to nyc_taxi_wide.parq

### DIFF
--- a/apps/taxi_player/main.py
+++ b/apps/taxi_player/main.py
@@ -19,7 +19,7 @@ hv.extension('bokeh')
 renderer = hv.renderer('bokeh').instance(mode='server')
 
 # Load data
-ddf = dd.read_parquet('./data/nyc_taxi_hours.parq/').persist()
+ddf = dd.read_parquet('./data/nyc_taxi_wide.parq').persist()
 
 from bokeh.models import WMTSTileSource
 url = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg'

--- a/datasets.yml
+++ b/datasets.yml
@@ -1,10 +1,10 @@
 ---
 
 data:
-  - url: https://s3.amazonaws.com/datashader-data/nyc_taxi_hours.zip
+  - url: https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq
     title: 'NYC Taxi Data'
     files:
-      - nyc_taxi_hours.parq
+      - nyc_taxi_wide.parq
 
   - url: http://s3.amazonaws.com/datashader-data/maccdc2012_graph.zip
     title: 'National CyberWatch Mid-Atlantic Collegiate Cyber Defense Competition'

--- a/notebooks/01-workflow-introduction.ipynb
+++ b/notebooks/01-workflow-introduction.ipynb
@@ -68,6 +68,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "slideshow": {
      "slide_type": "skip"
     }
@@ -111,7 +112,7 @@
     "<div class=\"alert alert-warning\" role=\"alert\">\n",
     "  <strong>Warning!</strong> If you are low on memory (less than 8 GB) load only a subset of the data by changing the line below to:\n",
     "  <br>\n",
-    "  <code>df = dd.read_parquet('../data/nyc_taxi_hours.parq/')[:10000].persist()</code>\n",
+    "  <code>df = dd.read_parquet('../data/nyc_taxi_wide.parq')[:10000].persist()</code>\n",
     "</div>"
    ]
   },
@@ -125,7 +126,7 @@
    },
    "outputs": [],
    "source": [
-    "%time df = dd.read_parquet('../data/nyc_taxi_hours.parq/').persist()\n",
+    "%time df = dd.read_parquet('../data/nyc_taxi_wide.parq').persist()\n",
     "print(len(df))\n",
     "df.head(2)"
    ]
@@ -347,6 +348,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -559,6 +561,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -761,7 +764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/notebooks/10-working-with-large-datasets.ipynb
+++ b/notebooks/10-working-with-large-datasets.ipynb
@@ -91,7 +91,7 @@
     "<div class=\"alert alert-warning\" role=\"alert\">\n",
     "  <strong>Warning!</strong> If you are low on memory (less than 8 GB) load only a subset of the data by changing the line below to:\n",
     "  <br>\n",
-    "  <code>df = dd.read_parquet('../data/nyc_taxi_hours.parq/')[:10000].persist()</code>\n",
+    "  <code>df = dd.read_parquet('../data/nyc_taxi_wide.parq')[:10000].persist()</code>\n",
     "</div>"
    ]
   },
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ddf = dd.read_parquet('../data/nyc_taxi_hours.parq/').persist()\n",
+    "ddf = dd.read_parquet('../data/nyc_taxi_wide.parq').persist()\n",
     "\n",
     "print('%s Rows' % len(ddf))\n",
     "print('Columns:', list(ddf.columns))"

--- a/notebooks/apps/nyc_taxi/main.py
+++ b/notebooks/apps/nyc_taxi/main.py
@@ -7,7 +7,7 @@ from holoviews.streams import RangeXY
 hv.extension('bokeh', logo=False)
 
 usecols = ['dropoff_x','dropoff_y','pickup_x','pickup_y','dropoff_hour','pickup_hour','passenger_count']
-df = dd.read_parquet('../../data/nyc_taxi_hours.parq/')[usecols].persist()
+df = dd.read_parquet('../../data/nyc_taxi_wide.parq')[usecols].persist()
 
 url='https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{Z}/{Y}/{X}.jpg'
 tiles = gv.WMTS(url,crs=crs.GOOGLE_MERCATOR)

--- a/notebooks/apps/server_app.py
+++ b/notebooks/apps/server_app.py
@@ -5,7 +5,7 @@ from holoviews.operation.datashader import datashade
 hv.extension('bokeh')
 
 # 1. Load data and Datashade it
-ddf = dd.read_parquet('../data/nyc_taxi_hours.parq/')[['dropoff_x', 'dropoff_y']].persist()
+ddf = dd.read_parquet('../data/nyc_taxi_wide.parq')[['dropoff_x', 'dropoff_y']].persist()
 points = hv.Points(ddf, kdims=['dropoff_x', 'dropoff_y'])
 shaded = datashade(points).opts(plot=dict(width=800, height=600))
 


### PR DESCRIPTION
Created a new taxi data Parquet file and uploaded it to S3, with a new filename to avoid confusion.  Script used:

```
import dask.dataframe as dd
import numpy as np
import pandas as pd

from fastparquet import write

floats = ['pickup_x', 'pickup_y', 'dropoff_x', 'dropoff_y', 'trip_distance', 'fare_amount', 'tip_amount']
shorts = ['passenger_count']
dates  = ['tpep_pickup_datetime','tpep_dropoff_datetime']

df = pd.read_csv('nyc_taxi.csv',usecols=floats+shorts+dates)

print(df.tail())
print(df.dtypes)

for i in floats: df[i] = df[i].astype(np.float32)
for i in dates:  df[i] = pd.to_datetime(df[i])

df['dropoff_hour'] = df.tpep_dropoff_datetime.dt.hour
df['pickup_hour']  = df.tpep_pickup_datetime.dt.hour
shorts += ['dropoff_hour','pickup_hour']

for i in shorts: df[i] = df[i].astype(np.uint8)

print(df.tail())
print(df.dtypes)

print("write parquet")
write('nyc_taxi_wide.parq', df, compression="SNAPPY", write_index=False, has_nulls=False)

print("read parquet")
df = dd.io.parquet.read_parquet('nyc_taxi_wide.parq')

print(df.tail())
print(df.dtypes)
```

Seems loadable in both Dask and Pandas 0.21.  Updated the various references to that file in this repo, but note that there still are some problems: 

- `cd notebooks/apps ; bokeh serve nyc_taxi` works, but the passenger selection doesn't seem to have any effect, and the hours widget shows NaN when used.  Maybe a parambokeh issue unrelated to this change?