### PR TITLE
Travis: removed stray deploy override (wrong, and no longer needed).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       before_install:
         # brew-installed geos interferes with cartopy?
         - brew uninstall --ignore-dependencies geos gdal postgis
-      if: branch = fix_travis_osx AND type != pull_request
+      if: branch = master AND type != pull_request
 
     - <<: *default
       stage: doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ jobs:
       before_install:
         # brew-installed geos interferes with cartopy?
         - brew uninstall --ignore-dependencies geos gdal postgis
-      if: branch = master AND type != pull_request
-      deploy: true
+      if: branch = fix_travis_osx AND type != pull_request
 
     - <<: *default
       stage: doc


### PR DESCRIPTION
@jbednar, this can be merged now. I cancelled all tests once I checked that travis osx started correctly, which is all this PR is supposed to fix.