### PR TITLE
Various website fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - sphinx-build -b html . ./_build/html
         - nbsite_fix_links.py _build/html
         - cp -r ../notebooks/assets _build/html/tutorial/
-        - touch ./_build/html/.nojekyll
+        - touch ./_build/html/.nojekyll # for github pages
         - nbsite_cleandisthtml.py ./_build/html take_a_chance
         - cd ..
       deploy:
@@ -68,6 +68,7 @@ jobs:
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
           local_dir: ./doc/_build/html
+          fqdn: pyviz.org
           on:
             tags: true
         - edge:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,27 +62,21 @@ jobs:
         - nbsite_cleandisthtml.py ./_build/html take_a_chance
         - cd ..
       deploy:
-        - edge:
-            branch: v1.8.47
-          provider: pages
+        - provider: pages
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
           local_dir: ./doc/_build/html
           fqdn: pyviz.org
           on:
             tags: true
-        - edge:
-            branch: v1.8.47
-          provider: pages
+        - provider: pages
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
           local_dir: ./doc/_build/html
           repo: ioam-docs/pyviz-master
           on:
             branch: master
-        - edge:
-            branch: v1.8.47
-          provider: pages
+        - provider: pages
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
           local_dir: ./doc/_build/html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@ html_context.update({
     'DESCRIPTION': description,
     'AUTHOR': authors,
     # will work without this - for canonical (so can ignore when building locally or test deploying)    
-    'WEBSITE_SERVER': 'https://pyviz.github.io/pyviz',
+    'WEBSITE_SERVER': 'http://pyviz.org',
     'VERSION': version,
     'NAV': _NAV,
     'LINKS': _NAV,

--- a/doc/tutorial/scipy18.rst
+++ b/doc/tutorial/scipy18.rst
@@ -1,0 +1,11 @@
+*******************
+SciPy 2018 tutorial
+*******************
+
+.. notebook:: pyviz ../../notebooks/scipy18.ipynb
+    :offset: 1
+
+
+-------
+
+`Right click to download this notebook from GitHub. <https://raw.githubusercontent.com/pyviz/pyviz/master/../../notebooks/scipy18.ipynb>`_


### PR DESCRIPTION
* Override scipy18 title 
* For the deployment to pyviz.github.io/pyviz, set custom domain to pyviz.org
* Set canonical URL to pyviz.org
* Remove travis/gh pages workaround that's no longer required (https://github.com/pyviz/nbsite/issues/38)

(To avoid having just 'scipy18' as the title of the scipy18 page, I edited the title of the generated rst stub, and committed the result.)