### PR TITLE
Update build.holoviews links to holoviews.

### DIFF
--- a/notebooks/02_Annotating_Data.ipynb
+++ b/notebooks/02_Annotating_Data.ipynb
@@ -374,7 +374,7 @@
    "source": [
     "Here ``country`` and ``year`` are possible key dimensions, determining what measurements were taken, and the rest of the columns are possible value dimensions, i.e., the results of those measurements. Notice that the dataframe itself makes no distinction between the two types of dimension; this is information that a human must supply to map the values into something meaningfully visualizable.\n",
     "\n",
-    "As an example, let's build an element that helps us understand how the percentage growth in US GDP varies over time. As our dataframe contains GDP growth data for lots of countries, let us select the United States from the table and create a [``Curve``](http://build.holoviews.org/reference/elements/bokeh/Curve.html) element from it:"
+    "As an example, let's build an element that helps us understand how the percentage growth in US GDP varies over time. As our dataframe contains GDP growth data for lots of countries, let us select the United States from the table and create a [``Curve``](http://holoviews.org/reference/elements/bokeh/Curve.html) element from it:"
    ]
   },
   {
@@ -512,7 +512,7 @@
     "\n",
     "## Composing elements together\n",
     "\n",
-    "As you saw above, we very often want to combine multiple elements into a single plot, both to save space and to show how things are related. In this section, we introduce the two composition operators ``+`` and ``*``, which build [``Layout``](http://build.holoviews.org/reference/containers/bokeh/Layout.html) and [``Overlay``](http://build.holoviews.org/reference/containers/bokeh/Overlay.html) objects.\n",
+    "As you saw above, we very often want to combine multiple elements into a single plot, both to save space and to show how things are related. In this section, we introduce the two composition operators ``+`` and ``*``, which build [``Layout``](http://holoviews.org/reference/containers/bokeh/Layout.html) and [``Overlay``](http://holoviews.org/reference/containers/bokeh/Overlay.html) objects.\n",
     "\n",
     "### Layouts\n",
     "\n",
@@ -535,7 +535,7 @@
    "source": [
     "Putting items together like this saves space, but even more importantly it acts as a declaration to HoloViews that these objects are related to each other.  HoloViews thus ensures that all of them will share the same axis ranges for all dimensions that match, and zooming or panning on any one of them will make the corresponding change to the others (try it!).  The [next section](03_Customizing_Visual_Appearance.ipynb) of this tutorial will describe how to change or override this behavior when appropriate.\n",
     "\n",
-    "If we look closely, we can see that the result of applying the ``+`` operator is an [``hv.Layout``](http://build.holoviews.org/reference/containers/bokeh/Layout.html) object (with a hint that a two-column layout is desired):"
+    "If we look closely, we can see that the result of applying the ``+`` operator is an [``hv.Layout``](http://holoviews.org/reference/containers/bokeh/Layout.html) object (with a hint that a two-column layout is desired):"
    ]
   },
   {
@@ -608,7 +608,7 @@
    "source": [
     "### Overlays\n",
     "\n",
-    "Layout places objects side by side, allowing it to collect (almost!) any HoloViews objects that you want to indicate are related.  Another operator ``*`` allows you to overlay elements into a single plot, if they live in the same space (with matching dimensions, and preferably with similar ranges over those dimensions).  The result of ``*`` is an [``Overlay``](http://build.holoviews.org/reference/containers/bokeh/Overlay.html):"
+    "Layout places objects side by side, allowing it to collect (almost!) any HoloViews objects that you want to indicate are related.  Another operator ``*`` allows you to overlay elements into a single plot, if they live in the same space (with matching dimensions, and preferably with similar ranges over those dimensions).  The result of ``*`` is an [``Overlay``](http://holoviews.org/reference/containers/bokeh/Overlay.html):"
    ]
   },
   {
@@ -624,7 +624,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The indexing system of [``Overlay``](http://build.holoviews.org/reference/containers/bokeh/Overlay.html) is identical to that of [``Layout``](http://build.holoviews.org/reference/containers/bokeh/Layout.html)."
+    "The indexing system of [``Overlay``](http://holoviews.org/reference/containers/bokeh/Overlay.html) is identical to that of [``Layout``](http://holoviews.org/reference/containers/bokeh/Layout.html)."
    ]
   },
   {

--- a/notebooks/03_Customizing_Visual_Appearance.ipynb
+++ b/notebooks/03_Customizing_Visual_Appearance.ipynb
@@ -394,7 +394,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll now introduce the [``Spikes``](http://build.holoviews.org/reference/elements/bokeh/Spikes.html) element, and display it with a large width, a log y-axis and some modifications to the xticks. We can specify those options for all following [``Spikes``](http://holoviews.org/reference/elements/bokeh/Spikes.html) elements using the ``%opts`` *line magic*:"
+    "We'll now introduce the [``Spikes``](http://holoviews.org/reference/elements/bokeh/Spikes.html) element, and display it with a large width, a log y-axis and some modifications to the xticks. We can specify those options for all following [``Spikes``](http://holoviews.org/reference/elements/bokeh/Spikes.html) elements using the ``%opts`` *line magic*:"
    ]
   },
   {

--- a/notebooks/04_Working_with_Tabular_Data.ipynb
+++ b/notebooks/04_Working_with_Tabular_Data.ipynb
@@ -414,7 +414,7 @@
     "\n",
     "## Onward\n",
     "\n",
-    "* Go through the Tabular Data [getting started](http://build.holoviews.org/getting_started/Tabular_Datasets.html) and [user guide](http://build.holoviews.org/user_guide/Tabular_Datasets.html).\n",
+    "* Go through the Tabular Data [getting started](http://holoviews.org/getting_started/Tabular_Datasets.html) and [user guide](http://holoviews.org/user_guide/Tabular_Datasets.html).\n",
     "* Learn about slicing, indexing and sampling in the [Indexing and Selecting Data](http://holoviews.org/user_guide/Indexing_and_Selecting_Data.html) user guide.\n",
     "\n",
     "The next section shows a similar approach, but for working with gridded data, in multidimensional array formats."


### PR DESCRIPTION
These links seem clearly wrong.

I also noticed that from about tutorial 04, there are no links onto the next notebook. But that might be deliberate (e.g. for different tutorial paths)...?