### PR TITLE
Minor tutorial fixups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
 stages:
   - test
   - name: conda_dev_package
-    if: tag =~ ^v(\d+|\.)*[a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: conda_package
-    if: tag =~ ^v(\d+|\.)*[^a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - doc
 
 jobs:

--- a/doc/tutorial/index.rst
+++ b/doc/tutorial/index.rst
@@ -14,7 +14,7 @@ PyViz Tutorial
     01 Workflow Introduction <01_Workflow_Introduction>
     02 Annotating Data <02_Annotating_Data>
     03 Customizing Visual Appearance <03_Customizing_Visual_Appearance>
-    04 Working with Datasets <04_Working_with_Datasets>
+    04 Working with Tabular Datasets <04_Working_with_Tabular_Data>
     05 Working with Gridded Data <05_Working_with_Gridded_Data>
     06 Network Graphs <06_Network_Graphs>
     07 Geographic Data <07_Geographic_Data>

--- a/notebooks/02_Annotating_Data.ipynb
+++ b/notebooks/02_Annotating_Data.ipynb
@@ -500,7 +500,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.BoxWhisker(economic_data, 'country', 'growth').options(xrotation=45)"
+    "hv.BoxWhisker(economic_data, 'country', 'growth')"
    ]
   },
   {

--- a/notebooks/04_Working_with_Tabular_Data.ipynb
+++ b/notebooks/04_Working_with_Tabular_Data.ipynb
@@ -417,7 +417,7 @@
     "* Go through the Tabular Data [getting started](http://holoviews.org/getting_started/Tabular_Datasets.html) and [user guide](http://holoviews.org/user_guide/Tabular_Datasets.html).\n",
     "* Learn about slicing, indexing and sampling in the [Indexing and Selecting Data](http://holoviews.org/user_guide/Indexing_and_Selecting_Data.html) user guide.\n",
     "\n",
-    "The next section shows a similar approach, but for working with gridded data, in multidimensional array formats."
+    "The [next section](./05_Working_with_Gridded_Data.ipynb) shows a similar approach, but for working with gridded data, in multidimensional array formats."
    ]
   }
  ],

--- a/notebooks/05_Working_with_Gridded_Data.ipynb
+++ b/notebooks/05_Working_with_Gridded_Data.ipynb
@@ -190,7 +190,7 @@
     "\n",
     "# Onwards\n",
     "\n",
-    "The previous sections focused on displaying plots that provide certain standard types of interactivity, whether widget-based (to select values along a dimension) or within each plot (for panning, zooming, etc.).  A wide range of additional types of interactivity can also be defined by the user for working with specific types of data, as outlined in the next section."
+    "The previous sections focused on displaying plots that provide certain standard types of interactivity, whether widget-based (to select values along a dimension) or within each plot (for panning, zooming, etc.).  A wide range of additional types of interactivity can also be defined by the user for working with specific types of data, as outlined in the following sections, beginning with [Network Graphs](./06_Network_Graphs.ipynb)."
    ]
   }
  ],

--- a/notebooks/06_Network_Graphs.ipynb
+++ b/notebooks/06_Network_Graphs.ipynb
@@ -390,6 +390,15 @@
    "source": [
     "bundled.select(circle='circle15', selection_mode='nodes')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Onwards\n",
+    "\n",
+    "Having seen how to visualize and interactively explore graphical data, we now go on to demonstrate how to visualize and explore a specific domain: [Geographic Data](./07_Geographic_Data.ipynb). While domain specific, geographic data is both very common and typically awkward to handle."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/07_Geographic_Data.ipynb
+++ b/notebooks/07_Geographic_Data.ipynb
@@ -228,7 +228,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See [geoviews.org](http://geoviews.org) and the [EarthSim](https://pyviz.github.io/EarthSim) site for more details on geographic tools that work well in PyViz."
+    "# Onwards\n",
+    "\n",
+    "See [geoviews.org](http://geoviews.org) and the [EarthSim](https://earthsim.pyviz.org) site for more details on geographic tools that work well in PyViz.\n",
+    "\n",
+    "Meanwhile, we now go on to show dynamic interactions, starting with [Custom Interactivity](./08_Custom_Interactivity)"
    ]
   }
  ],

--- a/notebooks/08_Custom_Interactivity.ipynb
+++ b/notebooks/08_Custom_Interactivity.ipynb
@@ -376,7 +376,7 @@
     "\n",
     "# Onwards\n",
     "\n",
-    "This visualization would be a good candidate for an online dashboard. We will see how you can deploy such visualizations using bokeh server in the [deploying bokeh apps](./11-deploying-bokeh-apps.ipynb) section, but first we will look at how we can handle truly large datasets in [Operations and Pipelines](./09_Operations_and_Pipelines.ipynb)."
+    "This visualization would be a good candidate for an online dashboard. We will see how you can deploy such visualizations using bokeh server in the [deploying bokeh apps](./11-deploying-bokeh-apps.ipynb) section, but first we will look at [Operations and Pipelines](./09_Operations_and_Pipelines.ipynb), which can be used to implement analyses or transformations while exploring a dataset."
    ]
   }
  ],

--- a/notebooks/08_Custom_Interactivity.ipynb
+++ b/notebooks/08_Custom_Interactivity.ipynb
@@ -376,7 +376,7 @@
     "\n",
     "# Onwards\n",
     "\n",
-    "This visualization would be a good candidate for an online dashboard. We will see how you can deploy such visualizations using bokeh server in the [deploying bokeh apps](./11-deploying-bokeh-apps.ipynb) section, but first we will look at how we can handle truly large datasets."
+    "This visualization would be a good candidate for an online dashboard. We will see how you can deploy such visualizations using bokeh server in the [deploying bokeh apps](./11-deploying-bokeh-apps.ipynb) section, but first we will look at how we can handle truly large datasets in [Operations and Pipelines](./09_Operations_and_Pipelines.ipynb)."
    ]
   }
  ],

--- a/notebooks/09_Operations_and_Pipelines.ipynb
+++ b/notebooks/09_Operations_and_Pipelines.ipynb
@@ -327,6 +327,15 @@
    "source": [
     "Reading from right to left, the original price timeseries is first smoothed with a rolling window, then datashaded, then each pixel is spread to cover a larger area. As you can see, arbitrarily many standard or custom operations can be defined to capture even very complex workflows so that they can be replayed dynamically as needed interactively."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Onwards\n",
+    "\n",
+    "Next we will look at how we can handle [large datasets](./10_Working_with_Large_Datasets.ipynb)."
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/10_Working_with_Large_Datasets.ipynb
+++ b/notebooks/10_Working_with_Large_Datasets.ipynb
@@ -288,10 +288,10 @@
     "\n",
     "# Onwards\n",
     "\n",
-    "* The [user guide](http://holoviews.org/user_guide/Large_Data.html) explains in more detail how to work with large datasets using datashader.\n",
-    "* There is a sample [bokeh app](http://holoviews.org/gallery/apps/bokeh/nytaxi_hover.html) using this dataset and an additional linked stream that works well as a starting point.\n",
+    "* The [HoloViews Large Data](http://holoviews.org/user_guide/Large_Data.html) user guide explains in more detail how to work with large datasets using datashader.\n",
+    "* HoloViews also contains a [sample bokeh app](http://holoviews.org/gallery/apps/bokeh/nytaxi_hover.html) using this dataset and an additional linked stream that works well as a starting point.\n",
     "\n",
-    "The final sections of this tutorial will show how to bring all of the concepts covered so far into an interactive web app for working with large or small datasets."
+    "Next, we go on to show how to create [live plots of dynamically updated data](./11_Streaming_Data.ipynb) (i.e. streaming data)."
    ]
   }
  ],

--- a/notebooks/11_Streaming_Data.ipynb
+++ b/notebooks/11_Streaming_Data.ipynb
@@ -551,7 +551,9 @@
     "\n",
     "<img class=\"gif\" src=\"http://assets.holoviews.org/gifs/guides/user_guide/Streaming_Data/streamz9.gif\"></img>\n",
     "\n",
-    "As you can see, streaming data works like streams in HoloViews in general, flexibly handling changes over time under either explicit control or governed by some external data source."
+    "As you can see, streaming data works like streams in HoloViews in general, flexibly handling changes over time under either explicit control or governed by some external data source.\n",
+    "\n",
+    "The final sections of this tutorial will show how to bring all of the concepts covered so far into an interactive web app for working with large or small datasets, starting with an introduction to [Parameters and Widgets](./12_Parameters_and_Widgets.ipynb)."
    ]
   }
  ],

--- a/notebooks/12_Parameters_and_Widgets.ipynb
+++ b/notebooks/12_Parameters_and_Widgets.ipynb
@@ -185,7 +185,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At present, only these relatively simple options for layout are supported, but these objects can be used in an arbitrary Jinja2 template (not shown), and additional Python layout options are expected to be added over time."
+    "At present, only these relatively simple options for layout are supported, but these objects can be used in an arbitrary Jinja2 template (not shown), and additional Python layout options are expected to be added over time.\n",
+    "\n",
+    "# Onwards\n",
+    "\n",
+    "The following section shows how to deploy your visualizations using [Bokeh server](./13_Deploying_Bokeh_Apps.ipynb)."
    ]
   }
  ],


### PR DESCRIPTION
* Added links to next sections (part of #42)
* Removed axis label rotation option currently incompatible with matplotlib backend (also part of #42)

Minor: Shouldn't have any impact at the moment, but modified the tag formats that trigger package builds. Require alpha tags to have a number (e.g. v0.1.2a1 rather than v0.1.2a), and support more than one digit for that number. (The available regex support and behavior varies depending on location in the travis file, so it's tricky to write them...)