### PR TITLE
Fix versioning of packages

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2017, IOAM
+Copyright (c) 2017-2018, PyViz developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst
+include LICENSE
+include pyviz/.version
+include pyviz/*.yml

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 import os
 import sys
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
+from setuptools import setup, find_packages
 import param.version
 
 setup_args = dict(
@@ -14,14 +10,14 @@ setup_args = dict(
     description='How to solve visualization problems with Python tools.',
     long_description=open('README.rst').read() if os.path.isfile('README.rst') else 'Consult README.rst',
     author= "PyViz developers",
-    author_email= " developers@pyviz.org",
+    author_email= "developers@pyviz.org",
     maintainer="PyViz developers",
-    maintainer_email=" developers@pyviz.org",
+    maintainer_email="developers@pyviz.org",
     entry_points = {
         'console_scripts': ['pyviz=pyviz.cmd:main'],
     },
-    packages = ["pyviz"],
-    package_data={'pyviz': ['*.yml']},
+    packages = find_packages(),
+    include_package_data=True,
     platforms=['Windows', 'Mac OS X', 'Linux'],
     license='BSD',
     url='http://pyviz.org',


### PR DESCRIPTION
I think #68 fell between the cracks and didn't get reviewed. Unfortunately I'd made an error - I didn't add anything to include the .version file in packages. So, recent pyviz releases will be returning "None" when asked for the version.

Also updated year and author in license file.