### PR TITLE
Update instructions to use pyviz/label/dev.

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -26,7 +26,7 @@ Step 2: Install ``pyviz`` and other required libraries
 
 ::
 
-   > conda install -c pyviz pyviz
+   > conda install -c pyviz/labe/dev pyviz
 
 
 Step 3: Install the tutorials in your current working directory and download data

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -26,7 +26,7 @@ Step 2: Install ``pyviz`` and other required libraries
 
 ::
 
-   > conda install -c pyviz/labe/dev pyviz
+   > conda install -c pyviz/label/dev pyviz
 
 
 Step 3: Install the tutorials in your current working directory and download data

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "! conda install -c pyviz pyviz\n",
+    "! conda install -c pyviz/label/dev pyviz\n",
     "! pyviz examples\n",
     "! cd pyviz-examples/tutorial\n",
     "! jupyter notebook\n",


### PR DESCRIPTION
Currently, anyone following the installation instructions on pyviz.org will get an older pyviz (0.9.11), because the current package (0.9.12) depends on dev releases of several things. However, the tutorial on pyviz.org expects the latest pyviz (0.9.12).

I noticed this in #81, which includes testing the "user installation" of packages (and those tests are failing).

If merged, subsequently pushing a tag like website_update (on master) should update pyviz.org. (I think, from reading the travis file! In #81 the mechanism is changing to the standard pyviz scheme, where there's definitely a deliberate `website` tag to allow updates between releases.)

EDIT: I also updated the environment.yaml file - tests on master have been failing too, since they use the environment.