### PR TITLE
First use of nbsite --skip, automatically touching .nojekyll file, cleaning arg added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,8 @@ jobs:
         - bokeh sampledata
         - pyviz fetch-data --path=examples --use-test-data
         # note: still more nbsite simplification to go...
-        - nbsite generate-rst --org pyviz --project-name pyviz --repo pyviz --offset 1 --skip '^.*Exercise.*$'
-        - nbsite build --what=html --output=builtdocs
-        - touch ./builtdocs/.nojekyll # for github pages
+        - nbsite generate-rst --org pyviz --project-name pyviz --offset 1 --skip '^.*Exercise.*$'
+        - nbsite build --what=html --output=builtdocs --for-github
         - nbsite_cleandisthtml.py ./builtdocs take_a_chance
       deploy:
         - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,8 @@ jobs:
         - doit develop_install $CHANS_DEV -o doc
         - bokeh sampledata
         - pyviz fetch-data --path=examples --use-test-data
-        # note: still more nbsite simplification to go...
         - nbsite generate-rst --org pyviz --project-name pyviz --offset 1 --skip '^.*Exercise.*$'
         - nbsite build --what=html --output=builtdocs
-        - nbsite_cleandisthtml.py ./builtdocs take_a_chance
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,8 @@ jobs:
         - doit develop_install $CHANS_DEV -o doc
         - bokeh sampledata
         - pyviz fetch-data --path=examples --use-test-data
-        # TODO: need to support skip for nbsite
-        - rm -rf examples/tutorial/exercises/Exercise*
         # note: still more nbsite simplification to go...
-        - nbsite generate-rst --org pyviz --project-name pyviz --repo pyviz --offset 1
+        - nbsite generate-rst --org pyviz --project-name pyviz --repo pyviz --offset 1 --skip '^.*Exercise.*$'
         - nbsite build --what=html --output=builtdocs
         - touch ./builtdocs/.nojekyll # for github pages
         - nbsite_cleandisthtml.py ./builtdocs take_a_chance

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - pyviz fetch-data --path=examples --use-test-data
         # note: still more nbsite simplification to go...
         - nbsite generate-rst --org pyviz --project-name pyviz --offset 1 --skip '^.*Exercise.*$'
-        - nbsite build --what=html --output=builtdocs --for-github
+        - nbsite build --what=html --output=builtdocs
         - nbsite_cleandisthtml.py ./builtdocs take_a_chance
       deploy:
         - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - bokeh sampledata
         - pyviz fetch-data --path=examples --use-test-data
         - nbsite generate-rst --org pyviz --project-name pyviz --offset 1 --skip '^.*Exercise.*$'
-        - nbsite build --what=html --output=builtdocs
+        - nbsite build --what=html --output=builtdocs --clean-force
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ tests =
     pytest >=2.8.5
 
 doc =
-    nbsite >=0.4.8
+    nbsite >=0.4.9
     sphinx_ioam_theme
 
 examples =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ tests =
     pytest >=2.8.5
 
 doc =
-    nbsite >=0.4.7
+    nbsite >=0.4.8
     sphinx_ioam_theme
 
 examples =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ tests =
     pytest >=2.8.5
 
 doc =
-    nbsite >=0.4.4
+    nbsite >=0.4.7
     sphinx_ioam_theme
 
 examples =


### PR DESCRIPTION
Won't be mergeable until after https://github.com/pyviz/nbsite/pull/93 lands and a version is bumped,
but first use of `nbsite generate-rst --skip` and not needing to touch .nojekyll anymore. Also cleaning up dist files be default.