### PR TITLE
For after 0.5.0 of nbsite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,12 @@ ENV/
 .mypy_cache/
 
 .doit*
+
+# nbsite
+# these files normally shouldn't be checked in as they should be
+# dynamically built from notebooks
+doc/**/*.rst
+doc/**/*.ipynb
+doc/**/*.json
+# this dir contains the whole website and should not be checked in on master
+builtdocs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
         - bokeh sampledata
         - pyviz fetch-data --path=examples --use-test-data
         - nbsite generate-rst --org pyviz --project-name pyviz --offset 1 --skip '^.*Exercise.*$'
-        - nbsite build --what=html --output=builtdocs --clean-force
+        - nbsite build --what=html --output=builtdocs
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ tests =
     pytest >=2.8.5
 
 doc =
-    nbsite >=0.4.9
+    nbsite >=0.5.0
     sphinx_ioam_theme
 
 examples =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ tests =
     pytest >=2.8.5
 
 doc =
-    nbsite >=0.5.0
+    nbsite >=0.5.1
     sphinx_ioam_theme
 
 examples =


### PR DESCRIPTION
After 0.5.0 of nbsite, evaluated notebooks live in `/doc` next to their dynamically generated `.rst` files. Lines are added to `.gitignore` to prevent accidental checking in of these files. Note that it is sometimes desirable to check in `doc/*.rst` files but it is preferable to generate them from notebooks. The workflow for re-evaluating a notebook and regenerating it's html is:

```bash
$ rm builtdocs/topics/nyc_taxi.html
$ rm doc/topics/nyc_taxi.ipynb
$ nbsite build --what=html --output=builtdocs
```

Upload the entire contents of `./builtdocs` to your server, or `gh-pages` branch to refresh your website.