### PR TITLE
Added .param to Panel param objects

### DIFF
--- a/examples/tutorial/01_Workflow_Introduction.ipynb
+++ b/examples/tutorial/01_Workflow_Introduction.ipynb
@@ -552,12 +552,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
     }
    },
+   "outputs": [],
    "source": [
     "%%output backend='matplotlib'\n",
     "by_state * hv.VLine(1963).options(color=\"black\") * \\\n",
@@ -724,7 +726,7 @@
     "        return tiles.options(alpha=self.alpha) * trips\n",
     "\n",
     "explorer = NYCTaxi(name=\"Taxi explorer\")\n",
-    "pn.Row(explorer, explorer.make_view).servable()\n"
+    "pn.Row(explorer.param, explorer.make_view).servable()\n"
    ]
   },
   {

--- a/examples/tutorial/apps/nyc_taxi/main.py
+++ b/examples/tutorial/apps/nyc_taxi/main.py
@@ -37,4 +37,4 @@ class NYCTaxiExplorer(param.Parameterized):
         return tiles * shade(agg, streams=[stream])
 
 taxi = NYCTaxiExplorer(name="NYC Taxi Trips")
-pn.Row(taxi, taxi.view()).servable()
+pn.Row(taxi.param, taxi.view()).servable()

--- a/examples/tutorial/apps/osm-1billion.py
+++ b/examples/tutorial/apps/osm-1billion.py
@@ -25,4 +25,4 @@ class OSM(param.Parameterized):
         return hv.DynamicMap(self.tiles) * shade(raster, streams=[hv.streams.Params(self, ['cmap'])])
 
 osm = OSM(name="Open Street Map GPS")
-pn.Row(osm, osm.view).servable()
+pn.Row(osm.param, osm.view).servable()


### PR DESCRIPTION
Updated outdated code so that when widgets are intended, the `.param` subobject is passed, not the entire Parameterized object.

Also restored Matplotlib backend example that had been commented out for some reason in tutorial 01.