### PR TITLE
Switch to using full dataset for website build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
         # TODO: set chans according to dev/rel (has to be dev for now because website currently depends on dev)
         - doit develop_install $CHANS_DEV -o doc
         - bokeh sampledata
-        - pyviz fetch-data --path=examples --use-test-data
+        - pyviz fetch-data --path=examples
         - nbsite generate-rst --org pyviz --project-name pyviz --offset 1 --skip '^.*Exercise.*$'
         - nbsite build --what=html --output=builtdocs
       deploy:


### PR DESCRIPTION
Locally the fetch data took about 250sec and the website build took another 250sec. So this should be fine while we iron out best practices for using an evaluated notebook branch (see earthml for that method)