### PR TITLE
Avoid full rerender in NYC taxi example

### DIFF
--- a/examples/tutorial/01_Workflow_Introduction.ipynb
+++ b/examples/tutorial/01_Workflow_Introduction.ipynb
@@ -726,7 +726,7 @@
     "        return tiles.options(alpha=self.alpha) * trips\n",
     "\n",
     "explorer = NYCTaxi(name=\"Taxi explorer\")\n",
-    "pn.Row(explorer.param, explorer.make_view).servable()\n"
+    "pn.Row(explorer.param, explorer.make_view()).servable()\n"
    ]
   },
   {


### PR DESCRIPTION
@jbednar I'm not sure how we can make the difference here clearer, but triggering a full rerender on each parameter change is definitely not desirable. I kind of regret not pushing back on the idea that an unannotated method implicitly depends on all parameters because of this.