### PR TITLE
Renaming pyviz -> holoviz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
     - &website
       <<: *default
       stage: website_release
-      env: DESC="Release website to pyviz.org" OPTIONS="-o doc -o geo -o indirect -o graph"
+      env: DESC="Release website to holoviz.org" OPTIONS="-o doc -o geo -o indirect -o graph"
       script:
         - bokeh sampledata
         - pyviz fetch-data --path=examples
@@ -99,7 +99,7 @@ jobs:
           skip_cleanup: true
           github_token: $GITHUB_TOKEN
           local_dir: ./builtdocs
-          fqdn: pyviz.org
+          fqdn: holoviz.org
           on:
             tags: true
             all_branches: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/pyviz/pyviz/blob/master/doc/_static/pyviz-logo.png"><br>
+<img src="https://github.com/pyviz/holoviz/blob/master/doc/_static/pyviz-logo.png"><br>
 
 -----------------
 
@@ -6,10 +6,10 @@
 
 |    |    |
 | --- | --- |
-| Build Status | [![Linux/MacOS Build Status](https://travis-ci.org/pyviz/pyviz.svg?branch=master)](https://travis-ci.org/pyviz/pyviz) [![Windows Build status](https://img.shields.io/appveyor/ci/pyviz/pyviz/master.svg?logo=appveyor)](https://ci.appveyor.com/project/pyviz/pyviz/branch/master) |
-| Latest dev release | [![Github tag](https://img.shields.io/github/tag/pyviz/pyviz.svg?label=tag&colorB=11ccbb)](https://github.com/pyviz/pyviz/tags) |
-| Latest release | [![Github release](https://img.shields.io/github/release/pyviz/pyviz.svg?label=tag&colorB=11ccbb)](https://github.com/pyviz/pyviz/releases) [![PyPI version](https://img.shields.io/pypi/v/pyviz.svg?colorB=cc77dd)](https://pypi.python.org/pypi/pyviz) [![pyviz version](https://img.shields.io/conda/v/pyviz/pyviz.svg?colorB=4488ff&style=flat)](https://anaconda.org/pyviz/pyviz) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/pyviz.svg?label=conda%7Cconda-forge&colorB=4488ff)](https://anaconda.org/conda-forge/pyviz) [![defaults version](https://img.shields.io/conda/v/anaconda/pyviz.svg?label=conda%7Cdefaults&style=flat&colorB=4488ff)](https://anaconda.org/anaconda/pyviz) |
-| Docs | [![gh-pages](https://img.shields.io/github/last-commit/pyviz/pyviz/gh-pages.svg)](https://github.com/pyviz/pyviz/tree/gh-pages) [![site](https://img.shields.io/website-up-down-green-red/http/holoviz.org.svg)](http://holoviz.org) |
+| Build Status | [![Linux/MacOS Build Status](https://travis-ci.org/pyviz/holoviz.svg?branch=master)](https://travis-ci.org/pyviz/holoviz) [![Windows Build status](https://img.shields.io/appveyor/ci/pyviz/holoviz/master.svg?logo=appveyor)](https://ci.appveyor.com/project/pyviz/holoviz/branch/master) |
+| Latest dev release | [![Github tag](https://img.shields.io/github/tag/pyviz/holoviz.svg?label=tag&colorB=11ccbb)](https://github.com/pyviz/holoviz/tags) |
+| Latest release | [![Github release](https://img.shields.io/github/release/pyviz/holoviz.svg?label=tag&colorB=11ccbb)](https://github.com/pyviz/holoviz/releases) [![PyPI version](https://img.shields.io/pypi/v/pyviz.svg?colorB=cc77dd)](https://pypi.python.org/pypi/pyviz) [![pyviz version](https://img.shields.io/conda/v/pyviz/pyviz.svg?colorB=4488ff&style=flat)](https://anaconda.org/pyviz/pyviz) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/pyviz.svg?label=conda%7Cconda-forge&colorB=4488ff)](https://anaconda.org/conda-forge/pyviz) [![defaults version](https://img.shields.io/conda/v/anaconda/pyviz.svg?label=conda%7Cdefaults&style=flat&colorB=4488ff)](https://anaconda.org/anaconda/pyviz) |
+| Docs | [![gh-pages](https://img.shields.io/github/last-commit/pyviz/holoviz/gh-pages.svg)](https://github.com/pyviz/holoviz/tree/gh-pages) [![site](https://img.shields.io/website-up-down-green-red/http/holoviz.org.svg)](http://holoviz.org) |
 | Dependencies | [![](https://img.shields.io/website-up-down-green-red/http/status.pyviz.org.svg?label=status-dashboard)](http://status.pyviz.org/) |
 
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 | Build Status | [![Linux/MacOS Build Status](https://travis-ci.org/pyviz/pyviz.svg?branch=master)](https://travis-ci.org/pyviz/pyviz) [![Windows Build status](https://img.shields.io/appveyor/ci/pyviz/pyviz/master.svg?logo=appveyor)](https://ci.appveyor.com/project/pyviz/pyviz/branch/master) |
 | Latest dev release | [![Github tag](https://img.shields.io/github/tag/pyviz/pyviz.svg?label=tag&colorB=11ccbb)](https://github.com/pyviz/pyviz/tags) |
 | Latest release | [![Github release](https://img.shields.io/github/release/pyviz/pyviz.svg?label=tag&colorB=11ccbb)](https://github.com/pyviz/pyviz/releases) [![PyPI version](https://img.shields.io/pypi/v/pyviz.svg?colorB=cc77dd)](https://pypi.python.org/pypi/pyviz) [![pyviz version](https://img.shields.io/conda/v/pyviz/pyviz.svg?colorB=4488ff&style=flat)](https://anaconda.org/pyviz/pyviz) [![conda-forge version](https://img.shields.io/conda/v/conda-forge/pyviz.svg?label=conda%7Cconda-forge&colorB=4488ff)](https://anaconda.org/conda-forge/pyviz) [![defaults version](https://img.shields.io/conda/v/anaconda/pyviz.svg?label=conda%7Cdefaults&style=flat&colorB=4488ff)](https://anaconda.org/anaconda/pyviz) |
-| Docs | [![gh-pages](https://img.shields.io/github/last-commit/pyviz/pyviz/gh-pages.svg)](https://github.com/pyviz/pyviz/tree/gh-pages) [![site](https://img.shields.io/website-up-down-green-red/http/pyviz.org.svg)](http://pyviz.org) |
+| Docs | [![gh-pages](https://img.shields.io/github/last-commit/pyviz/pyviz/gh-pages.svg)](https://github.com/pyviz/pyviz/tree/gh-pages) [![site](https://img.shields.io/website-up-down-green-red/http/holoviz.org.svg)](http://holoviz.org) |
 | Dependencies | [![](https://img.shields.io/website-up-down-green-red/http/status.pyviz.org.svg?label=status-dashboard)](http://status.pyviz.org/) |
 
 
-## What is it?	     
+## What is it?
 
 This repository provides examples, demos, and training materials
 documenting how to solve visualization problems using Python
@@ -32,10 +32,10 @@ starting points for solving your own visualization problems.
 
 ## Installation
 
-See [pyviz.org](http://pyviz.org/installation.html) (or doc/installation.rst for a github clone).
+See [holoviz.org](http://holoviz.org/installation.html) (or doc/installation.rst for a github clone).
 
 
-## About pyviz.org
+## About holoviz.org
 
 PyViz is a project supported in part by [Anaconda](https://anaconda.com).
 All projects used here are freely available for commercial or

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -41,6 +41,6 @@ html_context.update({
     'LINKS': _NAV,
     'SOCIAL': (
         ('Gitter', '//gitter.im/pyviz/pyviz'),
-        ('Github', '//github.com/pyviz/pyviz'),
+        ('Github', '//github.com/pyviz/holoviz'),
     )
 })

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,7 @@ html_context.update({
     'DESCRIPTION': description,
     'AUTHOR': authors,
     # WEBSITE_SERVER is optional for tests and local builds, but allows defining a canonical URL for search engines
-    'WEBSITE_SERVER': 'http://pyviz.org',
+    'WEBSITE_SERVER': 'http://holoviz.org',
     'VERSION': version,
     'NAV': _NAV,
     'LINKS': _NAV,

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "## Getting set up\n",
     "\n",
-    "Please consult [pyviz.org](http://pyviz.org/installation.html) for the full instructions on installing the software used in these tutorials. Here is the condensed version of those instructions, assuming you have already downloaded and installed [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://conda.io/miniconda.html):"
+    "Please consult [holoviz.org](http://holoviz.org/installation.html) for the full instructions on installing the software used in these tutorials. Here is the condensed version of those instructions, assuming you have already downloaded and installed [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://conda.io/miniconda.html):"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See the full instructions at [pyviz.org](http://pyviz.org/installation.html) if you don't yet have conda, or if you have an old version of conda. \n",
+    "See the full instructions at [holoviz.org](http://holoviz.org/installation.html) if you don't yet have conda, or if you have an old version of conda. \n",
     "\n",
     "Once everything is installed, run the following cell to test the key imports needed for this tutorial. If it completes without errors your environment should be ready to go:"
    ]

--- a/examples/tutorial/02_Annotating_Data.ipynb
+++ b/examples/tutorial/02_Annotating_Data.ipynb
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``hv.extension('bokeh')`` loads the [Bokeh](bokeh.pydata.org) plotting support in HoloViews; ``hv.extension('matplotlib')`` would use the [matplotlib](http://matplotlib.org) support instead. If ``pyviz`` is installed correctly as described at [pyviz.org](http://pyviz.org), you should see a HoloViews logo and a small Bokeh logo when you run the cell above."
+    "``hv.extension('bokeh')`` loads the [Bokeh](bokeh.pydata.org) plotting support in HoloViews; ``hv.extension('matplotlib')`` would use the [matplotlib](http://matplotlib.org) support instead. If ``pyviz`` is installed correctly as described at [holoviz.org](http://holoviz.org), you should see a HoloViews logo and a small Bokeh logo when you run the cell above."
    ]
   },
   {

--- a/examples/tutorial/11_Streaming_Data.ipynb
+++ b/examples/tutorial/11_Streaming_Data.ipynb
@@ -26,7 +26,7 @@
     "<a href=\"http://pandas.pydata.org\"><img style=\"margin:8px; display:inline; object-fit:scale-down; max-height:130px\" src=\"../assets/pandas.png\"/></a>\n",
     "</div>\n",
     "\n",
-    "Note that this page demonstrates functionality that requires a live, running Python server.  When exported to a static HTML page as on the pyviz.org website, you will only see a single plot.  When running this code as a Jupyter notebook, you should execute it cell by cell to see the effect of each operation in turn."
+    "Note that this page demonstrates functionality that requires a live, running Python server.  When exported to a static HTML page as on the holoviz.org website, you will only see a single plot.  When running this code as a Jupyter notebook, you should execute it cell by cell to see the effect of each operation in turn."
    ]
   },
   {

--- a/examples/tutorial/strata_ny18.ipynb
+++ b/examples/tutorial/strata_ny18.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "<img height=\"148\" width=\"800\" src=\"../assets/hv_gv_bk_ds_pa.png\"/>\n",
     "\n",
-    "These libraries have been carefully designed to work together to address a very wide range of data-analysis and visualization tasks, making it simple to discover, understand, and communicate the important properties of your data. For more background on these tools and why and how they are integrated, see [PyViz.org/background](http://pyviz.org/background.html).\n",
+    "These libraries have been carefully designed to work together to address a very wide range of data-analysis and visualization tasks, making it simple to discover, understand, and communicate the important properties of your data. For more background on these tools and why and how they are integrated, see [holoviz.org/background](http://holoviz.org/background.html).\n",
     "\n",
     "<img align=\"center\" src=\"../assets/tutorial_app.gif\"></img>\n",
     "\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,13 +17,13 @@ classifiers =
     Natural Language :: English
     Topic :: Scientific/Engineering
 author = PyViz developers
-author_email = developers@pyviz.org
+author_email = developers@holoviz.org
 maintainer = PyViz developers
 maintainer_email = developers@pyviz.org
-url = http://pyviz.org
+url = http://holoviz.org
 project_urls =
     Bug Tracker = https://github.com/pyviz/pyviz/issues
-    Documentation = http://pyviz.org
+    Documentation = http://holoviz.org
     Source Code = https://github.com/pyviz/pyviz
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,9 @@ maintainer = PyViz developers
 maintainer_email = developers@pyviz.org
 url = http://holoviz.org
 project_urls =
-    Bug Tracker = https://github.com/pyviz/pyviz/issues
+    Bug Tracker = https://github.com/pyviz/holoviz/issues
     Documentation = http://holoviz.org
-    Source Code = https://github.com/pyviz/pyviz
+    Source Code = https://github.com/pyviz/holoviz
 
 [options]
 include_package_data = True


### PR DESCRIPTION
 - changing pyviz.org -> holoviz.org
 - changing github pyviz/pyviz to pyviz/holoviz