### PR TITLE
DOC: tweak the wording around Matplotlib to be more accurate

### DIFF
--- a/examples/tutorial/04_Basic_Plotting.ipynb
+++ b/examples/tutorial/04_Basic_Plotting.ipynb
@@ -15,12 +15,12 @@
    "source": [
     "Previous sections have focused on putting various simple types of data together in notebooks and deployed servers, but most people will want to include plots as well. In this section, we'll focus on one of the simplest (but still powerful) ways to get a plot.\n",
     "\n",
-    "If you have tried to visualize a `pandas.DataFrame` before, then you have likely encountered the [Pandas .plot() API](https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html). This basic plotting interface uses [Matplotlib](http://matplotlib.org) to render static PNGs in a Jupyter notebook or for exporting from Python, with a command that can be as simple as `df.plot()` for a DataFrame with one or two columns. \n",
+    "If you have tried to visualize a `pandas.DataFrame` before, then you have likely encountered the [Pandas .plot() API](https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html). This basic plotting interface uses [Matplotlib](http://matplotlib.org) to render static PNGs or SVGs in a Jupyter notebook using the`inline` backend (or interactive figures via `%matplotlib notebook` or `%matplotlib widget`) and for exporting from Python, with a command that can be as simple as `df.plot()` for a DataFrame with one or two columns. \n",
     "\n",
     "The Pandas .plot() API has emerged as a de-facto standard for high-level plotting APIs in Python, and is now supported by many different libraries that use other underlying plotting engines to provide additional power and flexibility. Thus learning this API allows you to access capabilities provided by a wide variety of underlying tools, with relatively little additional effort. The libraries currently supporting this API include:\n",
     "\n",
-    "- [Pandas](https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html) -- Matplotlib-based API included with Pandas. Static PNG output in Jupyter notebooks.\n",
-    "- [xarray](https://xarray.pydata.org/en/stable/plotting.html) -- Matplotlib-based API included with xarray, based on pandas .plot API. Static PNG output in Jupyter notebooks.\n",
+    "- [Pandas](https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html) -- Matplotlib-based API included with Pandas. Static or interactive output in Jupyter notebooks.\n",
+    "- [xarray](https://xarray.pydata.org/en/stable/plotting.html) -- Matplotlib-based API included with xarray, based on pandas .plot API. Static or interactive output in Jupyter notebooks.\n",
     "- [hvPlot](https://hvplot.pyviz.org) -- HoloViews and Bokeh-based interactive plots for Pandas, GeoPandas, xarray, Dask, Intake, and Streamz data.\n",
     "- [Pandas Bokeh](https://github.com/PatrikHlobil/Pandas-Bokeh) -- Bokeh-based interactive plots, for Pandas, GeoPandas, and PySpark data.\n",
     "- [Cufflinks](https://github.com/santosjorge/cufflinks) -- Plotly-based interactive plots for Pandas data.\n",
@@ -136,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here unlike in the Pandas `.plot()` static PNG, if you hover over any of the datapoints, you can see the actual location values, and you can also pan and zoom to focus on any particular region of the data of interest.\n",
+    "Here unlike in the Pandas `.plot()` there is a default hover action on the datapoints to show the location values, and you can also pan and zoom to focus on any particular region of the data of interest.\n",
     "\n",
     "You might have noticed that many of the dots in the scatter that we've just created lie on top of one another. This is called [\"overplotting\"](http://datashader.org/user_guide/1_Plotting_Pitfalls.html#1.-Overplotting) and can be avoided in a variety of ways, such as by making the dots slightly transparent, or binning the data. These approaches have the downside of introducing bias because you need to choose the alpha or the edges of the bins, and in order to do that, you have to make assumptions about the data. For an initial exploration of a new dataset, it's much safer if you can just ***see*** the data, before you impose any assumptions about its form or structure. \n"
    ]


### PR DESCRIPTION
The inline backend is static, however nbagg (which ships with
Matplotlib, can be activated via `%matplotlib notebook` and works in
classic notebook) and ipypml (which is an independent package, can be
activated via `%matplotlib widget` and works in both classic notebook
and jupyterlab) provide interactive backends for the notebook.