### PR TITLE
Update 06_Interlinked_Plots.ipynb

### DIFF
--- a/examples/tutorial/06_Interlinked_Plots.ipynb
+++ b/examples/tutorial/06_Interlinked_Plots.ipynb
@@ -537,7 +537,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(esri * high_mag_quakes.opts(tools=['tap']) * labeller).opts(hv.opts.Scatter(tools=['hover']))"
+    "(esri * high_mag_quakes * labeller).opts(hv.opts.Points(tools=['tap', 'hover']))"
    ]
   },
   {


### PR DESCRIPTION
Scipy 2019 tutorial showed us that the hover tool didn't work as expected due to a typo in this cell. This was the update we used in class.