### PR TITLE
Remove testpath from setup.cfg

### DIFF
--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -1,3 +1,6 @@
+# file created by pyctdev:
+#   doit env_export2 --env-name-again=holoviz --env-file=examples/environment.yml --package-name=holoviz -c pyviz -c defaults --pin-deps
+
 name: holoviz-tutorial
 channels:
   - pyviz
@@ -28,4 +31,5 @@ dependencies:
   - scikit-image
   - selenium
   - streamz ==0.5.0
+  - testpath ==0.3.1
   - xarray ==0.12.1

--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -31,5 +31,4 @@ dependencies:
   - scikit-image
   - selenium
   - streamz ==0.5.0
-  - testpath ==0.3.1
   - xarray ==0.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,8 +57,6 @@ install_requires =
     selenium
     # inadvertent dependency of streamz
     ipywidgets
-    # unstated dependency of datashader?
-    testpath <0.4
 
 [options.extras_require]
 tests =
@@ -117,7 +115,6 @@ pins =
     numpy = 1.16.4
     pandas = 0.24.0
     xarray = 0.12.1
-    testpath = 0.3.1
 
 [tool:pyctdev.conda]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,13 +52,13 @@ install_requires =
     # for reading .nc files
     netcdf4
     # for reading Parquet files (minimum version required by pandas 0.24)
-    fastparquet>=0.2.1
+    fastparquet >=0.2.1
     # for exporting Bokeh plots to PNG
     selenium
     # inadvertent dependency of streamz
     ipywidgets
     # unstated dependency of datashader?
-    testpath<0.4
+    testpath <0.4
 
 [options.extras_require]
 tests =
@@ -117,6 +117,7 @@ pins =
     numpy = 1.16.4
     pandas = 0.24.0
     xarray = 0.12.1
+    testpath = 0.3.1
 
 [tool:pyctdev.conda]
 


### PR DESCRIPTION
testpath isn't in environment.yaml, so I removed it from setup.cfg too. Maybe the original problem has now gone away - any idea before I look up the history?

Notes:
- The original reason for this PR was just to try out a new dev release of pyctdev (0.6.0a8). That _seems_ to have worked. 
- I also checked that generating the environment file using pyctdev results in the same environment file we currently have.
