### PR TITLE
Fix snappy support on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 
 stages:
   - name: test_user_install
+    if: type = cron  
   - test
   - name: package_dev
     if: tag =~ ^v(\d+|\.)+[a-z]\d+$

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
     - <<: *package_test
       env: DESC="Test package on pip"
       script:
-        - sudo apt-get install libsnappy-dev
+        - sudo apt-get install libsnappy-dev python3-dev
         - doit test_user_install_part2_pip
 
     - <<: *package_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 
 stages:
   - name: test_user_install
-    if: type = cron  
+    if: type = cron
   - test
   - name: package_dev
     if: tag =~ ^v(\d+|\.)+[a-z]\d+$

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,8 @@ jobs:
     - <<: *package_test
       env: DESC="Test package on pip"
       script:
-#        - sudo apt-get install libsnappy-dev python3-dev
+# TODO: needs to be documented for pip users, e.g. "pip users will need to install snappy's dependencies via their system packaging tool"
+        - sudo apt-get install libsnappy-dev python3-dev
         - doit test_user_install_part2_pip
 
     - <<: *package_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
     - <<: *package_test
       env: DESC="Test package on pip"
       script:
-        - sudo apt-get install libsnappy-dev python3-dev
+#        - sudo apt-get install libsnappy-dev python3-dev
         - doit test_user_install_part2_pip
 
     - <<: *package_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 
 stages:
   - name: test_user_install
-    if: type = cron
   - test
   - name: package_dev
     if: tag =~ ^v(\d+|\.)+[a-z]\d+$

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ jobs:
     - <<: *package_test
       env: DESC="Test package on pip"
       script:
-        - sudo apt-get install snappy
+        - sudo apt-get install libsnappy-dev
         - doit test_user_install_part2_pip
 
     - <<: *package_test

--- a/dodo.py
+++ b/dodo.py
@@ -18,6 +18,7 @@ def task_test_user_install_part2_conda():
 def task_test_user_install_part2_pip():
     return {'actions':[
         # would need to be documented: "pip users will need to install snappy e.g. via their system packaging tool (how to do this varies between platforms - or use conda)"
+        "conda install -y snappy",
         "pip install python-snappy",
         "pip install holoviz nbsmoke",
         "holoviz examples --path=. --force --use-test-data",

--- a/dodo.py
+++ b/dodo.py
@@ -17,6 +17,8 @@ def task_test_user_install_part2_conda():
 
 def task_test_user_install_part2_pip():
     return {'actions':[
+        # would need to be documented: "pip users will need to install snappy e.g. via their system packaging tool (how to do this varies between platforms - or use conda)"
+        "pip install python-snappy",
         "pip install holoviz nbsmoke",
         "holoviz examples --path=. --force --use-test-data",
         # TODO: bokeh sampledata isn't a documented step

--- a/dodo.py
+++ b/dodo.py
@@ -17,9 +17,7 @@ def task_test_user_install_part2_conda():
 
 def task_test_user_install_part2_pip():
     return {'actions':[
-        # would need to be documented: "pip users will need to install snappy e.g. via their system packaging tool (how to do this varies between platforms - or use conda)"
-        "conda install -y snappy",
-        "pip install python-snappy",
+        "pip install python-snappy", # TODO should rearrange dependencies so this can be installed via an option
         "pip install holoviz nbsmoke",
         "holoviz examples --path=. --force --use-test-data",
         # TODO: bokeh sampledata isn't a documented step


### PR DESCRIPTION
Doesn't replace the value of deciding about #220, but fixes the failing travis builds. Would still require documentation like "pip users will need to install python-snappy's system dependencies using their system package manager". 

The successful pip/package test run is "test package on pip" at https://travis-ci.org/holoviz/holoviz/builds/621299758 (that usually only runs for cron/master - I temporarily enabled for this PR, then disabled again).

Note: python-snappy appears to have binary wheels for macos. Maybe we should ask if it would be possible to get wheels for all platforms? (Though I have no idea if the macos wheels contain all the necessary dependencies anyway...)
