### PR TITLE
For "unpinned upcoming trouble" build, use "next python" (currently set to 3.7).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ env:
     - CHANS_REL="-c conda-forge -c defaults -c https://conda.anaconda.org/pyviz"  # this order matters because we're using strict channel priority
     - LABELS_DEV="--label dev"
     - LABELS_REL="--label dev --label main"
-    # TODO: is PYENV_VERSION used in more than one place?
+    # TODO: is PYENV_VERSION used in more than one place? (And document what it's for.)
     - PYENV_VERSION=3.7
     - PYTHON_VERSION=3.6
+    - NEXT_PYTHON_VERSION=3.7
     # TODO: this should probably be set based on PYTHON_VERSION
     - PKG_TEST_PYTHON="--test-python=py36"
     - PIN="--pin-deps"
@@ -74,7 +75,7 @@ jobs:
         - python -c "from pyct import cmd; cmd.clean_data(name='holoviz', path='examples')"
     - <<: *default
       stage: unpinned_upcoming_trouble
-      env: PIN= PYTHON_VERSION=
+      env: PIN= PYTHON_VERSION=$NEXT_PYTHON_VERSION
 
     - &package_test
       <<: *default

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,13 @@ stages:
   - name: website_release
     if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website)
   - name: unpinned_upcoming_trouble
-#    if: type = cron
+    if: type = cron
 # TODO: caching
 
 jobs:
   include:
     - &default
-      stage: testTODOskipfornow
+      stage: test
       env: DESC="Test examples" OPTIONS="-o graph -o indirect -o tests"
       os: linux
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 language: generic
 os:
   - linux
@@ -88,9 +87,13 @@ jobs:
 
     - <<: *package_test
       env: DESC="Test package on pip"
+      addons:
+        apt:
+          packages:
+          # TODO: needs to be documented for pip users, e.g. "pip users will need to install snappy's dependencies via their system packaging tool"	 
+          - libsnappy-dev
+          - python3-dev
       script:
-# TODO: needs to be documented for pip users, e.g. "pip users will need to install snappy's dependencies via their system packaging tool"
-        - sudo apt-get install libsnappy-dev python3-dev
         - doit test_user_install_part2_pip
 
     - <<: *package_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ env:
     - CHANS_REL="-c conda-forge -c defaults -c https://conda.anaconda.org/pyviz"  # this order matters because we're using strict channel priority
     - LABELS_DEV="--label dev"
     - LABELS_REL="--label dev --label main"
+    # TODO: is PYENV_VERSION used in more than one place?
     - PYENV_VERSION=3.7
     - PYTHON_VERSION=3.6
+    # TODO: this should probably be set based on PYTHON_VERSION
     - PKG_TEST_PYTHON="--test-python=py36"
     - PIN="--pin-deps"
     - CHANS=$CHANS_DEV
@@ -28,7 +30,7 @@ stages:
   - name: website_release
     if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website)
   - name: unpinned_upcoming_trouble
-    if: type = cron
+#    if: type = cron
 # TODO: caching
 
 jobs:
@@ -72,7 +74,7 @@ jobs:
         - python -c "from pyct import cmd; cmd.clean_data(name='holoviz', path='examples')"
     - <<: *default
       stage: unpinned_upcoming_trouble
-      env: PIN=
+      env: PIN= PYTHON_VERSION=
 
     - &package_test
       <<: *default

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ stages:
 jobs:
   include:
     - &default
-      stage: test
+      stage: testTODOskipfornow
       env: DESC="Test examples" OPTIONS="-o graph -o indirect -o tests"
       os: linux
       install:
@@ -60,7 +60,6 @@ jobs:
         - holoviz clean-data --path=examples
 
     - <<: *default
-      stage: test
       env: DESC="Test examples using environment.yml"
       os: linux
       before_script:


### PR DESCRIPTION
The cron "unpinned" build started failing recently. I don't think we can keep this build passing all the time, so usually I'd leave it, but I need to investigate for other work.

![Screenshot from 2019-12-20 14-34-26](https://user-images.githubusercontent.com/1929/71261687-ecb8e300-2335-11ea-8384-71a349a7d6af.png)

https://travis-ci.org/holoviz/holoviz/jobs/627538104#L665:
```
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
Solving environment: ...working... failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... failed with initial frozen solve. Retrying with flexible solve.
Solving environment: ...working... 
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.
failed
UnsatisfiableError: The following specifications were found to be incompatible with each other:
[...]
Note that strict channel priority may have removed packages required for satisfiability.
```