### PR TITLE
Replace earthquake data with downsampled version on binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,5 +3,6 @@ jupyter serverextension enable panel.io.jupyter_server_extension
 cd examples
 anaconda-project prepare
 cd data
+rm earthquakes-projected.parq
 wget -q https://s3.eu-west-1.amazonaws.com/assets.holoviews.org/data/earthquakes-projected.parq
 cd ../..


### PR DESCRIPTION
Previously it wouldn't overwrite the larger file so you had to manually rename to get that to work.