### PR TITLE
Project channels: remove nodefaults, append defaults

### DIFF
--- a/examples/anaconda-project.yml
+++ b/examples/anaconda-project.yml
@@ -5,7 +5,7 @@ maintainers:
 - holoviz
 
 user_fields: [maintainers]
-channels: [pyviz/label/dev,conda-forge,nodefaults]
+channels: [pyviz/label/dev,conda-forge,defaults]
 
 packages: &pkgs
 - python=3.9


### PR DESCRIPTION
- Removing `nodefaults` as it was actually not taken account before anaconda-project 0.11
- appending `defaults` even if anaconda-project 0.11.1 will do so by default, yet it's better to be explicit.