### PR TITLE
Add code of conduct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ examples/output/
 holoviz/examples/
 jupyter_execute/
 .version
+
+.vscode

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -51,10 +51,9 @@ decisions when appropriate.
 ## Scope
 
 This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+an individual is representing the community in public spaces.
+
+Our community consists of contributors in their efforts related to the development and distribution of any materials for the HoloViz organization. The projects in this community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz), such as Param, HoloViews, hvPlot, Panel, GeoViews, Lumen, Datashader, and Colorcet. Other efforts, whether online or in-person, undertaken by this community and coordinated through [HoloViz communication channels](https://holoviz.org/community.html) are also covered under this Code of Conduct. This code applies equally to founders, developers, mentors and new community members, in all spaces managed by HoloViz. In addition, violations of this code outside these spaces may affect a person’s ability to participate within them.
 
 ## Reporting
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,121 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the HoloViz Code of Conduct committee at
+[TODO: conduct@holoviz.org???](mailto:), or by filling out [TODO: this form]() which can be submitted anonymously. Currently, the committee consists of:
+* James Bednar [@jbednar](https://github.com/jbednar)
+* TODO: ???
+
+All complaints will be reviewed and investigated promptly and fairly.
+All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,15 +69,15 @@ If your complaint involves anyone who is on this list, please reach out separate
 
 If you choose to email instead of using the form, please include the following information:
 
-* Your contact info (not required, if you would like to remain anonymous please use the form)
+* Your contact info (if you would like us to be able to follow up or collect additional information)
 * Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, try to include them as well
 * When and where the incident occurred. Please be as specific as possible.
 * Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or GitHub/gitter.im) please include a link
-* Any extra context you believe exists for the incident
+* Any extra context you believe is relevant for the incident
 * If you believe this incident is ongoing
 * Any other information you believe we should have
 
-*Note*: with anonymous reports, there are inherent limits in our ability to do follow-up or collect additional information. Hence we suggest that if you would like to remain anonymous, you can also create a throw-away email address without your real name.
+*Note*: with anonymous reports, there are inherent limits in our ability to do follow-up or collect additional information. If you are uncomfortable sharing your identity, consider creating a throw-away email address without your real name so that we will be able to reach you.
 
 All complaints will be reviewed and investigated promptly and fairly. All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately. 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,12 +36,23 @@ Examples of unacceptable behavior include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
-# Diversity Statement
-We welcome and encourage participation in our community by people of all backgrounds and identities. We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning, and we work together as a community to help each other live out these values.
+## Diversity Statement
 
-We have created this diversity statement because we believe that a diverse community is stronger, more vibrant, and produces better software and better science. A diverse community where people treat each other with respect has more potential contributors, more sources for ideas, and fewer shared assumptions that might hinder development or research.
+We welcome and encourage participation in our community by people of all backgrounds
+and identities. We are committed to promoting and sustaining a culture that values
+mutual respect, tolerance, and learning, and we work together as a community to
+help each other live out these values.
 
-Although we have phrased the formal diversity statement generically to make it all-inclusive, we recognize that there are specific identities that are impacted by systemic discrimination and marginalization. We welcome all people to participate in the HoloViz Organization and community regardless of their identity or background.
+We have created this diversity statement because we believe that a diverse community
+is stronger, more vibrant, and produces better software and better science. A diverse
+community where people treat each other with respect has more potential contributors,
+more sources for ideas, and fewer shared assumptions that might hinder development
+or research.
+
+Although we have phrased the formal diversity statement generically to make it all-inclusive,
+we recognize that there are specific identities that are impacted by systemic discrimination
+and marginalization. We welcome all people to participate in the HoloViz Organization
+and community regardless of their identity or background.
 
 ## Enforcement Responsibilities
 
@@ -60,32 +71,56 @@ decisions when appropriate.
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is representing the community in public spaces.
 
-Our community consists of contributors in their efforts related to the development and distribution of any materials for the HoloViz organization. The projects in this community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz), such as Colorcet, Datashader, GeoViews, HoloViews, hvPlot, Lumen, Panel, and Param. Other efforts, whether online or in-person, undertaken by this community and coordinated through [HoloViz communication channels](https://holoviz.org/community.html) are also covered under this Code of Conduct. This code applies equally to founders, developers, mentors and new community members, in all spaces managed by HoloViz. In addition, violations of this code outside these spaces may affect a person’s ability to participate within them.
+Our community consists of contributors in their efforts related to the development
+and distribution of any materials for the HoloViz organization. The projects in this
+community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz),
+such as Colorcet, Datashader, GeoViews, HoloViews, hvPlot, Lumen, Panel, and Param.
+Other efforts, whether online or in-person, undertaken by this community and coordinated
+through [HoloViz communication channels](https://holoviz.org/community.html) are
+also covered under this Code of Conduct. This code applies equally to founders,
+developers, mentors and new community members, in all spaces managed by HoloViz.
+In addition, violations of this code outside these spaces may affect a person’s ability
+to participate within them.
 
 ## Reporting
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the HoloViz Code of Conduct committee at
-[holoviz.conduct@gmail.com](mailto:holoviz.conduct@gmail.com), or by filling out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfeb8zVV8ugTPJ33YFSm18K_eTSQRubb4Dn_iRYeu8uniCmSQ/viewform?usp=sf_link) which can be submitted anonymously. Currently, the committee consists of:
+[holoviz.conduct@gmail.com](mailto:holoviz.conduct@gmail.com), or by filling out
+[this form](https://docs.google.com/forms/d/e/1FAIpQLSfeb8zVV8ugTPJ33YFSm18K_eTSQRubb4Dn_iRYeu8uniCmSQ/viewform?usp=sf_link)
+which can be submitted anonymously. Currently, the committee consists of:
+
 * Sophia Yang [@sophiamyang](https://github.com/sophiamyang/)
 * Marc Skov Madsen [@MarcSkovMadsen](https://github.com/MarcSkovMadsen)
 * Philipp Rudiger [@philippjfr](https://github.com/philippjfr)
 
-If your complaint involves anyone who is on this list, please reach out separately to one or more members of the list who have not been involved in the behavior in question. If a report involves a member of the listed committee, that member will not participate in the investigation or any decisions related to that report.
+If your complaint involves anyone who is on this list, please reach out separately
+to one or more members of the list who have not been involved in the behavior in
+question. If a report involves a member of the listed committee, that member will
+not participate in the investigation or any decisions related to that report.
 
 If you choose to email instead of using the form, please include the following information:
 
-* Your contact info (if you would like us to be able to follow up or collect additional information)
-* Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, try to include them as well
+* Your contact info (if you would like us to be able to follow up or collect additional
+information)
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there were
+other witnesses besides you, try to include them as well
 * When and where the incident occurred (please be as specific as possible)
-* Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or GitHub/gitter.im) please include a link
+* Your account of what occurred. If there is a publicly available record (e.g. a
+mailing list archive or GitHub/Gitter) please include a link
 * Any extra context you believe is relevant for the incident
 * If you believe this incident is ongoing
 * Any other information you believe we should have
 
-*Note*: with anonymous reports, there are inherent limits in our ability to do follow-up or collect additional information. If you are uncomfortable sharing your identity, consider creating a throw-away email address without your real name so that we will be able to reach you.
+*Note*: with anonymous reports, there are inherent limits in our ability to do follow-up
+or collect additional information. If you are uncomfortable sharing your identity,
+consider creating a throw-away email address without your real name so that we will
+be able to reach you.
 
-All complaints will be reviewed and investigated promptly and fairly. All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately. 
+All complaints will be reviewed and investigated promptly and fairly. All Code of
+Conduct committee members are obligated to respect the privacy and security of the
+reporter of any incident. Further details of committee membership policies may be
+posted separately.
 
 ## Enforcement Guidelines
 
@@ -138,5 +173,6 @@ community.
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)
 version 2.1.
 
-Sections of this text also benefitted from [Django](https://www.djangoproject.com/conduct/reporting/) and [Jupyter](https://jupyter.org/governance/conduct/reporting_online.html) reporting guidelines. 
-
+Sections of this text also benefitted from [Django](https://www.djangoproject.com/conduct/reporting/)
+and [Jupyter](https://jupyter.org/governance/conduct/reporting_online.html) reporting
+guidelines.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,6 +36,13 @@ Examples of unacceptable behavior include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
+# Diversity Statement
+We welcome and encourage participation in our community by people of all backgrounds and identities. We are committed to promoting and sustaining a culture that values mutual respect, tolerance, and learning, and we work together as a community to help each other live out these values.
+
+We have created this diversity statement because we believe that a diverse community is stronger, more vibrant, and produces better software and better science. A diverse community where people treat each other with respect has more potential contributors, more sources for ideas, and fewer shared assumptions that might hinder development or research.
+
+Although we have phrased the formal diversity statement generically to make it all-inclusive, we recognize that there are specific identities that are impacted by systemic discrimination and marginalization. We welcome all people to participate in the HoloViz Organization and community regardless of their identity or background.
+
 ## Enforcement Responsibilities
 
 Community leaders are responsible for clarifying and enforcing our standards of

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ Our community consists of contributors in their efforts related to the developme
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the HoloViz Code of Conduct committee at
-[coc@holoviz.org](mailto:coc@holoviz.org), or by filling out [TODO: this form]() which can be submitted anonymously. Currently, the committee consists of:
+[holoviz.conduct@gmail.com](mailto:holoviz.conduct@gmail.com), or by filling out [TODO: this form]() which can be submitted anonymously. Currently, the committee consists of:
 * James Bednar [@jbednar](https://github.com/jbednar)
 * Marc Skov Madsen [@MarcSkovMadsen](https://github.com/MarcSkovMadsen)
 * Philipp Rudiger [@philippjfr](https://github.com/philippjfr)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,12 +60,12 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the HoloViz Code of Conduct committee at
-[TODO: conduct@holoviz.org???](mailto:), or by filling out [TODO: this form]() which can be submitted anonymously. Currently, the committee consists of:
+[coc@holoviz.org](mailto:coc@holoviz.org), or by filling out [TODO: this form]() which can be submitted anonymously. Currently, the committee consists of:
 * James Bednar [@jbednar](https://github.com/jbednar)
-* TODO: ???
+* Marc Skov Madsen [@MarcSkovMadsen](https://github.com/MarcSkovMadsen)
+* Philipp Rudiger [@philippjfr](https://github.com/philippjfr)
 
-All complaints will be reviewed and investigated promptly and fairly.
-All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately.
+If your complaint involves anyone who is on this list, please reach out separately to one or more members of the list who have not been involved in the behavior in question. All complaints will be reviewed and investigated promptly and fairly. All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately. 
 
 ## Enforcement Guidelines
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ decisions when appropriate.
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is representing the community in public spaces.
 
-Our community consists of contributors in their efforts related to the development and distribution of any materials for the HoloViz organization. The projects in this community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz), such as Param, HoloViews, hvPlot, Panel, GeoViews, Lumen, Datashader, and Colorcet. Other efforts, whether online or in-person, undertaken by this community and coordinated through [HoloViz communication channels](https://holoviz.org/community.html) are also covered under this Code of Conduct. This code applies equally to founders, developers, mentors and new community members, in all spaces managed by HoloViz. In addition, violations of this code outside these spaces may affect a person’s ability to participate within them.
+Our community consists of contributors in their efforts related to the development and distribution of any materials for the HoloViz organization. The projects in this community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz), such as Colorcet, Datashader, GeoViews, HoloViews, hvPlot, Lumen, Panel, Param. Other efforts, whether online or in-person, undertaken by this community and coordinated through [HoloViz communication channels](https://holoviz.org/community.html) are also covered under this Code of Conduct. This code applies equally to founders, developers, mentors and new community members, in all spaces managed by HoloViz. In addition, violations of this code outside these spaces may affect a person’s ability to participate within them.
 
 ## Reporting
 
@@ -70,7 +70,7 @@ If you choose to email instead of using the form, please include the following i
 
 * Your contact info (if you would like us to be able to follow up or collect additional information)
 * Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, try to include them as well
-* When and where the incident occurred. Please be as specific as possible.
+* When and where the incident occurred (please be as specific as possible)
 * Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or GitHub/gitter.im) please include a link
 * Any extra context you believe is relevant for the incident
 * If you believe this incident is ongoing

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -67,7 +67,7 @@ Our community consists of contributors in their efforts related to the developme
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the HoloViz Code of Conduct committee at
 [holoviz.conduct@gmail.com](mailto:holoviz.conduct@gmail.com), or by filling out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfeb8zVV8ugTPJ33YFSm18K_eTSQRubb4Dn_iRYeu8uniCmSQ/viewform?usp=sf_link) which can be submitted anonymously. Currently, the committee consists of:
-* James Bednar [@jbednar](https://github.com/jbednar)
+* Sophia Yang [@sophiamyang](https://github.com/sophiamyang/)
 * Marc Skov Madsen [@MarcSkovMadsen](https://github.com/MarcSkovMadsen)
 * Philipp Rudiger [@philippjfr](https://github.com/philippjfr)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ Our community consists of contributors in their efforts related to the developme
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the HoloViz Code of Conduct committee at
-[holoviz.conduct@gmail.com](mailto:holoviz.conduct@gmail.com), or by filling out [TODO: this form]() which can be submitted anonymously. Currently, the committee consists of:
+[holoviz.conduct@gmail.com](mailto:holoviz.conduct@gmail.com), or by filling out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfeb8zVV8ugTPJ33YFSm18K_eTSQRubb4Dn_iRYeu8uniCmSQ/viewform?usp=sf_link) which can be submitted anonymously. Currently, the committee consists of:
 * James Bednar [@jbednar](https://github.com/jbednar)
 * Marc Skov Madsen [@MarcSkovMadsen](https://github.com/MarcSkovMadsen)
 * Philipp Rudiger [@philippjfr](https://github.com/philippjfr)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,7 @@ Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
-## Enforcement
+## Reporting
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the HoloViz Code of Conduct committee at
@@ -65,7 +65,21 @@ reported to the HoloViz Code of Conduct committee at
 * Marc Skov Madsen [@MarcSkovMadsen](https://github.com/MarcSkovMadsen)
 * Philipp Rudiger [@philippjfr](https://github.com/philippjfr)
 
-If your complaint involves anyone who is on this list, please reach out separately to one or more members of the list who have not been involved in the behavior in question. All complaints will be reviewed and investigated promptly and fairly. All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately. 
+If your complaint involves anyone who is on this list, please reach out separately to one or more members of the list who have not been involved in the behavior in question. If a report involves a member of the listed committee, that member will not participate in the investigation or any decisions related to that report.
+
+If you choose to email instead of using the form, please include the following information:
+
+* Your contact info (not required, if you would like to remain anonymous please use the form)
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, try to include them as well
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or GitHub/gitter.im) please include a link
+* Any extra context you believe exists for the incident
+* If you believe this incident is ongoing
+* Any other information you believe we should have
+
+*Note*: with anonymous reports, there are inherent limits in our ability to do follow-up or collect additional information. Hence we suggest that if you would like to remain anonymous, you can also create a throw-away email address without your real name.
+
+All complaints will be reviewed and investigated promptly and fairly. All Code of Conduct committee members are obligated to respect the privacy and security of the reporter of any incident. Further details of committee membership policies may be posted separately. 
 
 ## Enforcement Guidelines
 
@@ -115,7 +129,8 @@ community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)
+version 2.1.
+
+Sections of this text also benefitted from [Django](https://www.djangoproject.com/conduct/reporting/) and [Jupyter](https://jupyter.org/governance/conduct/reporting_online.html) reporting guidelines. 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ decisions when appropriate.
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is representing the community in public spaces.
 
-Our community consists of contributors in their efforts related to the development and distribution of any materials for the HoloViz organization. The projects in this community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz), such as Param, HoloViews, hvPlot, Panel, GeoViews, Lumen, Datashader, and Colorcet. Other efforts, whether online or in-person, undertaken by this community and coordinated through [HoloViz communication channels](https://holoviz.org/community.html) are also covered under this Code of Conduct. This code applies equally to founders, developers, mentors and new community members, in all spaces managed by HoloViz. In addition, violations of this code outside these spaces may affect a person’s ability to participate within them.
+Our community consists of contributors in their efforts related to the development and distribution of any materials for the HoloViz organization. The projects in this community include the repositories in the [HoloViz GitHub organization](https://github.com/holoviz), such as Colorcet, Datashader, GeoViews, HoloViews, hvPlot, Lumen, Panel, and Param. Other efforts, whether online or in-person, undertaken by this community and coordinated through [HoloViz communication channels](https://holoviz.org/community.html) are also covered under this Code of Conduct. This code applies equally to founders, developers, mentors and new community members, in all spaces managed by HoloViz. In addition, violations of this code outside these spaces may affect a person’s ability to participate within them.
 
 ## Reporting
 
@@ -70,7 +70,7 @@ If you choose to email instead of using the form, please include the following i
 
 * Your contact info (if you would like us to be able to follow up or collect additional information)
 * Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, try to include them as well
-* When and where the incident occurred. Please be as specific as possible.
+* When and where the incident occurred (please be as specific as possible)
 * Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or GitHub/gitter.im) please include a link
 * Any extra context you believe is relevant for the incident
 * If you believe this incident is ongoing

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 | Docs | [![gh-pages](https://img.shields.io/github/last-commit/holoviz/holoviz/gh-pages.svg)](https://github.com/holoviz/holoviz/tree/gh-pages) [![site](https://img.shields.io/website-up-down-green-red/http/holoviz.org.svg)](http://holoviz.org) [![dev-site](https://img.shields.io/website-up-down-green-red/https/pyviz-dev.github.io/holoviz.svg?label=dev%20website)](https://pyviz-dev.github.io/holoviz/)  |
 | Status Dashboard | [![](https://img.shields.io/website-up-down-green-red/http/status.holoviz.org.svg?label=status-dashboard)](http://status.holoviz.org/) |
 | Binder  | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/holoviz/holoviz/HEAD?labpath=examples%2Ftutorial%2F00_Setup.ipynb) |
+| Code of Conduct | [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)|
 
 
 ## What is it?


### PR DESCRIPTION
Having a code of conduct will help us maintain a healthy community and establish explicit conduct guidelines and enforcement mechanisms potentially required by future partner/funding opportunities. 

TODO/TODISCUSS:
- [x] (1) set up email address for receiving reports. update: not using `coc@holoviz.org`, instead I have set up `holoviz.conduct@gmail.com` so that the conduct team can simply own the reporting form and data.
- [x] (2) create a form for anonymous submissions. examples: [dask](https://docs.google.com/forms/d/e/1FAIpQLScR80riHtoUQFqhpKOWkD8x-mSkHhyIMoeZk8OdSCEGO6Eshg/viewform), [Jupyter](https://docs.google.com/forms/d/e/1FAIpQLSfUuaGbXrH0anroNIkbc-dBrn-ISsC_BA57IRt57aQW85nK6w/viewform?c=0&w=1) forms.

This code of conduct is mainly adapted from https://www.contributor-covenant.org/ with some additional reporting guidelines from https://www.djangoproject.com/conduct/reporting/. I also reviewed [xarray](https://github.com/pydata/xarray/blob/main/CODE_OF_CONDUCT.md), [matplotlib](https://github.com/matplotlib/matplotlib/blob/main/CODE_OF_CONDUCT.md), [dask](https://github.com/dask/governance/blob/main/code-of-conduct.md), [Jupyter](https://jupyter.org/governance/conduct/code_of_conduct.html#:~:text=Be%20careful%20in%20the%20words,exclusionary%20behavior%20are%20not%20acceptable.), [Django](https://www.djangoproject.com/conduct/reporting/), and [pandas](https://github.com/pandas-dev/pandas-governance) code of conduct docs. 

This PR's CoC is similar to Panel's CoC https://github.com/holoviz/panel/pull/2892. Important differences include public declaration of who is on the receiving end of the reporting, defining the community, and further reporting guidelines. I think it is most appropriate to have our code of conduct on the root dir of HoloViz repo. We can then link to this from the individual HoloViz packages' docs.

Please leave a thumbs up or accept the review to accept the code of conduct