### PR TITLE
Enable libmamba

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,6 +48,8 @@ jobs:
       - name: conda setup
         run: |
           conda update -n base -c defaults conda
+          conda install conda-libmamba-solver
+          conda config --set solver libmamba
           conda create -n test-environment -c pyviz/label/dev -c conda-forge python=3.9 
       - name: doit develop_install
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: conda setup
         run: |
           conda update -n base -c defaults conda
+          conda activate base
           conda install conda-libmamba-solver
           conda config --set solver libmamba
           conda create -n test-environment -c pyviz/label/dev -c conda-forge python=3.9 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,16 +47,14 @@ jobs:
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: conda setup
         run: |
-          conda update -n base -c defaults conda
           conda activate base
           conda install conda-libmamba-solver
           conda config --set solver libmamba
-          conda create -n test-environment -c pyviz/label/dev -c conda-forge python=3.9 
+          conda create -n test-environment -c pyviz/label/dev -c conda-forge python=3.9 anaconda-project
       - name: doit develop_install
         run: |
           conda activate test-environment
           conda list
-          conda install anaconda-project
           cd examples
           anaconda-project prepare --env-spec doc
           cd ..

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,8 @@ jobs:
         run: git fetch --prune --tags --unshallow
       - name: conda setup
         run: |
-          conda config --set always_yes True
+          conda install conda-libmamba-solver
+          conda config --set solver libmamba
           conda install -c pyviz "pyctdev>=0.5"
           doit env_create --python=${{ matrix.python-version }}
       - name: doit develop_install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,19 +46,11 @@ jobs:
         run: git fetch --prune --tags --unshallow
       - name: conda setup
         run: |
-          conda update -n base -c defaults conda
           conda activate base
           conda install conda-libmamba-solver
           conda config --set solver libmamba
           conda install -c pyviz "pyctdev>=0.5"
-          doit env_create --python=${{ matrix.python-version }}
-      - name: doit develop_install
-        run: |
-          conda activate test-environment
-          conda list
-          conda install anaconda-project>=0.10.1
-          echo "-----"
-          git describe
+          conda create -c pyviz --name test-environment python=${{ matrix.python-version }} pyctdev anaconda-project>=0.10.1
       - name: doit env_capture
         run: |
           conda activate test-environment

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
         run: git fetch --prune --tags --unshallow
       - name: conda setup
         run: |
+          conda update -n base -c defaults conda
           conda install conda-libmamba-solver
           conda config --set solver libmamba
           conda install -c pyviz "pyctdev>=0.5"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: conda setup
         run: |
           conda update -n base -c defaults conda
+          conda activate base
           conda install conda-libmamba-solver
           conda config --set solver libmamba
           conda install -c pyviz "pyctdev>=0.5"

--- a/examples/anaconda-project-lock.yml
+++ b/examples/anaconda-project-lock.yml
@@ -25,77 +25,76 @@ env_specs:
     - win-64
     packages:
       all:
-      - _ipython_minor_entry_point=8.7.0=h8cf3c4a_0
       - anyio=3.6.2=pyhd8ed1ab_0
+      - appdirs=1.4.4=pyh9f0ad1d_0
       - argon2-cffi=21.3.0=pyhd8ed1ab_0
       - asttokens=2.2.1=pyhd8ed1ab_0
-      - attrs=22.1.0=pyh71513ae_1
+      - attrs=22.2.0=pyh71513ae_0
       - babel=2.11.0=pyhd8ed1ab_0
       - backcall=0.2.0=pyh9f0ad1d_0
       - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
       - backports=1.0=pyhd8ed1ab_3
       - beautifulsoup4=4.11.1=pyha770c72_0
-      - bleach=5.0.1=pyhd8ed1ab_0
+      - bleach=6.0.0=pyhd8ed1ab_0
       - certifi=2022.12.7=pyhd8ed1ab_0
       - charset-normalizer=2.1.1=pyhd8ed1ab_0
-      - cloudpickle=2.2.0=pyhd8ed1ab_0
+      - cloudpickle=2.2.1=pyhd8ed1ab_0
       - colorama=0.4.6=pyhd8ed1ab_0
       - colorcet=3.0.1=py_0
       - comm=0.1.2=pyhd8ed1ab_0
       - cycler=0.11.0=pyhd8ed1ab_0
-      - dask-core=2022.12.1=pyhd8ed1ab_0
-      - dask=2022.12.1=pyhd8ed1ab_0
+      - dask-core=2023.1.1=pyhd8ed1ab_0
+      - dask=2023.1.1=pyhd8ed1ab_0
       - datashader=0.14.1=py_0
       - datashape=0.5.4=py_1
       - decorator=5.1.1=pyhd8ed1ab_0
       - defusedxml=0.7.1=pyhd8ed1ab_0
-      - distributed=2022.12.1=pyhd8ed1ab_0
+      - distributed=2023.1.1=pyhd8ed1ab_0
       - entrypoints=0.4=pyhd8ed1ab_0
-      - exceptiongroup=1.0.4=pyhd8ed1ab_0
+      - exceptiongroup=1.1.0=pyhd8ed1ab_0
       - executing=1.2.0=pyhd8ed1ab_0
       - flit-core=3.8.0=pyhd8ed1ab_0
-      - fsspec=2022.11.0=pyhd8ed1ab_0
+      - fsspec=2023.1.0=pyhd8ed1ab_0
       - heapdict=1.0.1=py_0
       - holoviews=1.15.0=py_0
       - hvplot=0.8.0=py_0
       - idna=3.4=pyhd8ed1ab_0
-      - importlib-metadata=5.2.0=pyha770c72_0
-      - importlib_resources=5.10.1=pyhd8ed1ab_0
-      - iniconfig=1.1.1=pyh9f0ad1d_0
+      - importlib-metadata=6.0.0=pyha770c72_0
+      - importlib_resources=5.10.2=pyhd8ed1ab_0
+      - iniconfig=2.0.0=pyhd8ed1ab_0
       - ipympl=0.9.2=pyhd8ed1ab_0
       - ipython_genutils=0.2.0=py_1
-      - ipywidgets=7.7.2=pyhd8ed1ab_0
+      - ipywidgets=8.0.4=pyhd8ed1ab_0
       - jedi=0.18.2=pyhd8ed1ab_0
       - jinja2=3.1.2=pyhd8ed1ab_1
       - json5=0.9.5=pyh9f0ad1d_0
       - jsonschema=4.17.3=pyhd8ed1ab_0
-      - jupyter_client=7.4.8=pyhd8ed1ab_0
+      - jupyter_client=7.4.9=pyhd8ed1ab_0
       - jupyter_contrib_core=0.4.0=pyhd8ed1ab_0
-      - jupyter_events=0.5.0=pyhd8ed1ab_0
+      - jupyter_events=0.6.3=pyhd8ed1ab_0
       - jupyter_nbextensions_configurator=0.6.1=pyhd8ed1ab_0
-      - jupyter_server=2.0.2=pyhd8ed1ab_0
-      - jupyter_server_terminals=0.4.3=pyhd8ed1ab_0
-      - jupyterlab=3.5.2=pyhd8ed1ab_0
+      - jupyter_server=2.1.0=pyhd8ed1ab_0
+      - jupyter_server_terminals=0.4.4=pyhd8ed1ab_1
+      - jupyterlab=3.5.3=pyhd8ed1ab_0
       - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
-      - jupyterlab_server=2.16.5=pyhd8ed1ab_0
-      - jupyterlab_widgets=1.1.1=pyhd8ed1ab_0
+      - jupyterlab_server=2.19.0=pyhd8ed1ab_0
+      - jupyterlab_widgets=3.0.5=pyhd8ed1ab_0
       - locket=1.0.0=pyhd8ed1ab_0
       - markdown=3.4.1=pyhd8ed1ab_0
       - matplotlib-inline=0.1.6=pyhd8ed1ab_0
       - mistune=2.0.4=pyhd8ed1ab_0
       - multipledispatch=0.6.0=py_0
-      - munkres=1.1.4=pyh9f0ad1d_0
       - nbclassic=0.4.8=pyhd8ed1ab_0
       - nbclient=0.7.2=pyhd8ed1ab_0
-      - nbconvert-core=7.2.7=pyhd8ed1ab_0
-      - nbconvert-pandoc=7.2.7=pyhd8ed1ab_0
-      - nbconvert=7.2.7=pyhd8ed1ab_0
-      - nbformat=5.7.1=pyhd8ed1ab_0
+      - nbconvert-core=7.2.9=pyhd8ed1ab_0
+      - nbconvert-pandoc=7.2.9=pyhd8ed1ab_0
+      - nbconvert=7.2.9=pyhd8ed1ab_0
+      - nbformat=5.7.3=pyhd8ed1ab_0
       - nbsmoke=0.6.1a1=py_0
       - nest-asyncio=1.5.6=pyhd8ed1ab_0
       - notebook-shim=0.2.2=pyhd8ed1ab_0
       - notebook=6.5.2=pyha770c72_1
-      - packaging=22.0=pyhd8ed1ab_0
+      - packaging=23.0=pyhd8ed1ab_0
       - pandocfilters=1.5.0=pyhd8ed1ab_0
       - panel=0.13.1=py_0
       - param=1.12.2=py_0
@@ -103,27 +102,31 @@ env_specs:
       - partd=1.3.0=pyhd8ed1ab_0
       - pip=22.3.1=pyhd8ed1ab_0
       - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
-      - platformdirs=2.6.0=pyhd8ed1ab_0
-      - plotly=5.11.0=pyhd8ed1ab_1
-      - prometheus_client=0.15.0=pyhd8ed1ab_0
+      - platformdirs=2.6.2=pyhd8ed1ab_0
+      - plotly=5.13.0=pyhd8ed1ab_0
+      - pooch=1.6.0=pyhd8ed1ab_0
+      - prometheus_client=0.16.0=pyhd8ed1ab_0
       - prompt-toolkit=3.0.36=pyha770c72_0
       - pure_eval=0.2.2=pyhd8ed1ab_0
       - pycparser=2.21=pyhd8ed1ab_0
       - pyct-core=0.4.8=py_0
       - pyct=0.4.8=py_0
       - pyflakes=3.0.1=pyhd8ed1ab_0
-      - pygments=2.13.0=pyhd8ed1ab_0
-      - pyopenssl=22.1.0=pyhd8ed1ab_0
+      - pygments=2.14.0=pyhd8ed1ab_0
+      - pyopenssl=23.0.0=pyhd8ed1ab_0
       - pyparsing=3.0.9=pyhd8ed1ab_0
+      - pytest=7.2.1=pyhd8ed1ab_0
       - python-dateutil=2.8.2=pyhd8ed1ab_0
       - python-fastjsonschema=2.16.2=pyhd8ed1ab_0
-      - python-json-logger=2.0.1=pyh9f0ad1d_0
+      - python-json-logger=2.0.4=pyhd8ed1ab_0
       - python_abi=3.9=3_cp39
-      - pytz=2022.7=pyhd8ed1ab_0
+      - pytz=2022.7.1=pyhd8ed1ab_0
       - pyviz_comms=2.2.1=py_0
-      - requests=2.28.1=pyhd8ed1ab_1
+      - requests=2.28.2=pyhd8ed1ab_0
+      - rfc3339-validator=0.1.4=pyhd8ed1ab_0
+      - rfc3986-validator=0.1.1=pyh9f0ad1d_0
       - send2trash=1.8.0=pyhd8ed1ab_0
-      - setuptools=65.6.3=pyhd8ed1ab_0
+      - setuptools=66.1.1=pyhd8ed1ab_0
       - six=1.16.0=pyh6c4a22f_0
       - sniffio=1.3.0=pyhd8ed1ab_0
       - sortedcontainers=2.4.0=pyhd8ed1ab_0
@@ -135,34 +138,33 @@ env_specs:
       - tomli=2.0.1=pyhd8ed1ab_0
       - toolz=0.12.0=pyhd8ed1ab_0
       - tqdm=4.64.1=pyhd8ed1ab_0
-      - traitlets=5.8.0=pyhd8ed1ab_0
+      - traitlets=5.8.1=pyhd8ed1ab_0
+      - typing-extensions=4.4.0=hd8ed1ab_0
       - typing_extensions=4.4.0=pyha770c72_0
       - tzdata=2022g=h191b570_0
-      - urllib3=1.26.13=pyhd8ed1ab_0
-      - wcwidth=0.2.5=pyh9f0ad1d_2
+      - urllib3=1.26.14=pyhd8ed1ab_0
+      - wcwidth=0.2.6=pyhd8ed1ab_0
       - webencodings=0.5.1=py_1
-      - websocket-client=1.4.2=pyhd8ed1ab_0
+      - websocket-client=1.5.0=pyhd8ed1ab_0
       - wheel=0.38.4=pyhd8ed1ab_0
-      - widgetsnbextension=3.6.1=pyha770c72_0
-      - xarray=2022.12.0=pyhd8ed1ab_0
+      - widgetsnbextension=4.0.5=pyhd8ed1ab_0
+      - xarray=2023.1.0=pyhd8ed1ab_0
       - zict=2.2.0=pyhd8ed1ab_0
-      - zipp=3.11.0=pyhd8ed1ab_0
+      - zipp=3.12.0=pyhd8ed1ab_0
       unix:
       - pexpect=4.8.0=pyh1a96a4e_2
       - ptyprocess=0.7.0=pyhd3deb0d_0
       osx:
       - appnope=0.1.3=pyhd8ed1ab_0
-      - ipykernel=6.19.4=pyh736e0ef_0
-      - ipython=8.7.0=pyhd1c38e8_0
+      - ipykernel=6.20.2=pyh736e0ef_0
+      - ipython=8.9.0=pyhd1c38e8_0
+      - munkres=1.1.4=pyh9f0ad1d_0
       - terminado=0.17.1=pyhd1c38e8_0
       linux-64:
       - _libgcc_mutex=0.1=conda_forge
       - _openmp_mutex=4.5=2_gnu
-      - alsa-lib=1.2.3.2=h166bdaf_0
       - argon2-cffi-bindings=21.2.0=py39hb9d737c_3
       - bokeh=2.4.3=py39hf3d152e_0
-      - brotli-bin=1.0.9=h166bdaf_8
-      - brotli=1.0.9=h166bdaf_8
       - brotlipy=0.7.0=py39hb9d737c_1005
       - bzip2=1.0.8=h7f98852_4
       - c-ares=1.18.1=h7f98852_0
@@ -170,135 +172,95 @@ env_specs:
       - cffi=1.15.1=py39he91dace_3
       - cftime=1.6.2=py39h2ae25f5_1
       - click=8.1.3=py39hf3d152e_1
-      - contourpy=1.0.6=py39hf939315_0
       - cramjam=2.6.2=py39h4ef89ea_0
-      - cryptography=38.0.4=py39hd97740a_0
-      - curl=7.87.0=h6312ad2_0
+      - cryptography=39.0.0=py39h079d5ae_0
+      - curl=7.87.0=hdc1c0ab_0
       - cytoolz=0.12.0=py39hb9d737c_1
-      - dbus=1.13.6=h5008d03_3
-      - debugpy=1.6.4=py39h5a03fae_0
-      - expat=2.5.0=h27087fc_0
-      - fastparquet=2022.12.0=py39h389d5f1_0
-      - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
-      - font-ttf-inconsolata=3.000=h77eed37_0
-      - font-ttf-source-code-pro=2.038=h77eed37_0
-      - font-ttf-ubuntu=0.83=hab24e00_0
-      - fontconfig=2.14.1=hc2a2eb6_0
-      - fonts-conda-ecosystem=1=0
-      - fonts-conda-forge=1=0
-      - fonttools=4.38.0=py39hb9d737c_1
+      - debugpy=1.6.6=py39h227be39_0
+      - fastparquet=2023.1.0=py39h389d5f1_0
       - freetype=2.12.1=hca18f0e_1
-      - gettext=0.21.1=h27087fc_0
-      - glib-tools=2.74.1=h6239696_1
-      - glib=2.74.1=h6239696_1
-      - gst-plugins-base=1.20.2=hcf0ee16_0
-      - gstreamer=1.20.3=hd4edc92_2
       - hdf4=4.2.15=h9772cbc_5
-      - hdf5=1.12.2=nompi_h2386368_100
-      - icu=69.1=h9c3ff4c_0
-      - ipykernel=6.19.4=pyh210e3f2_0
-      - ipython=8.7.0=pyh41d4057_0
+      - hdf5=1.12.2=nompi_h4df4325_101
+      - icu=70.1=h27087fc_0
+      - ipykernel=6.20.2=pyh210e3f2_0
+      - ipython=8.9.0=pyh41d4057_0
       - jpeg=9e=h166bdaf_2
-      - jupyter_core=5.1.0=py39hf3d152e_0
+      - jupyter_core=5.1.5=py39hf3d152e_0
       - keyutils=1.6.1=h166bdaf_0
       - kiwisolver=1.4.4=py39hf939315_1
-      - krb5=1.20.1=hf9c8cef_0
+      - krb5=1.20.1=h81ceb04_0
       - lcms2=2.14=hfd0df8a_1
-      - ld_impl_linux-64=2.39=hcc3a1bd_1
+      - ld_impl_linux-64=2.40=h41732ed_0
       - lerc=4.0.0=h27087fc_0
+      - libaec=1.0.6=hcb278e6_1
       - libblas=3.9.0=16_linux64_openblas
-      - libbrotlicommon=1.0.9=h166bdaf_8
-      - libbrotlidec=1.0.9=h166bdaf_8
-      - libbrotlienc=1.0.9=h166bdaf_8
       - libcblas=3.9.0=16_linux64_openblas
-      - libclang=13.0.1=default_hc23dcda_0
-      - libcurl=7.87.0=h6312ad2_0
-      - libdeflate=1.14=h166bdaf_0
+      - libcurl=7.87.0=hdc1c0ab_0
+      - libdeflate=1.17=h0b41bf4_0
       - libedit=3.1.20191231=he28a2e2_2
       - libev=4.33=h516909a_1
-      - libevent=2.1.10=h9b69904_4
       - libffi=3.4.2=h7f98852_5
       - libgcc-ng=12.2.0=h65d4601_19
       - libgfortran-ng=12.2.0=h69a702a_19
       - libgfortran5=12.2.0=h337968e_19
-      - libglib=2.74.1=h606061b_1
       - libgomp=12.2.0=h65d4601_19
       - libiconv=1.17=h166bdaf_0
+      - libjpeg-turbo=2.1.4=h166bdaf_0
       - liblapack=3.9.0=16_linux64_openblas
       - libllvm11=11.1.0=he0ac6c6_5
-      - libllvm13=13.0.1=hf817b99_2
-      - libnetcdf=4.8.1=nompi_h21705cb_104
-      - libnghttp2=1.47.0=hdcd2b5c_1
+      - libnetcdf=4.8.1=nompi_h261ec11_106
+      - libnghttp2=1.51.0=hff17c54_0
       - libnsl=2.0.0=h7f98852_0
-      - libogg=1.3.4=h7f98852_1
       - libopenblas=0.3.21=pthreads_h78a6416_3
-      - libopus=1.3.1=h7f98852_1
       - libpng=1.6.39=h753d276_0
-      - libpq=14.5=h2baec63_4
       - libsodium=1.0.18=h36c2ea0_1
       - libsqlite=3.40.0=h753d276_0
-      - libssh2=1.10.0=haa6b8db_3
+      - libssh2=1.10.0=hf14f497_3
       - libstdcxx-ng=12.2.0=h46fd767_19
-      - libtiff=4.5.0=h82bc61c_0
+      - libtiff=4.5.0=h6adf6a1_2
       - libuuid=2.32.1=h7f98852_1000
-      - libvorbis=1.3.7=h9c3ff4c_0
       - libwebp-base=1.2.4=h166bdaf_0
       - libxcb=1.13=h7f98852_1004
-      - libxkbcommon=1.0.3=he3ba5ed_0
-      - libxml2=2.9.12=h885dcf4_1
-      - libzip=1.9.2=hc869a4a_1
+      - libxml2=2.10.3=h7463322_0
+      - libzip=1.9.2=hc929e4a_1
       - libzlib=1.2.13=h166bdaf_4
       - llvmlite=0.39.1=py39h7d9a04d_1
-      - lz4-c=1.9.3=h9c3ff4c_1
-      - lz4=4.0.2=py39h029007f_0
-      - markupsafe=2.1.1=py39hb9d737c_2
-      - matplotlib-base=3.6.2=py39hf9fd14e_0
-      - matplotlib=3.6.2=py39hf3d152e_0
+      - lz4-c=1.9.4=hcb278e6_0
+      - lz4=4.2.0=py39h724f13c_0
+      - markupsafe=2.1.2=py39h72bdee0_0
+      - matplotlib-base=3.3.2=py39h98787fa_1
+      - matplotlib=3.3.2=0
       - msgpack-python=1.0.4=py39hf939315_1
-      - mysql-common=8.0.31=haf5c9bc_0
-      - mysql-libs=8.0.31=h28c427c_0
       - ncurses=6.3=h27087fc_1
       - netcdf4=1.6.2=nompi_py39hfaa66c4_100
-      - nspr=4.35=h27087fc_0
-      - nss=3.82=he02c5a1_0
       - numba=0.56.4=py39h61ddf18_0
       - numpy=1.23.5=py39h3d75532_0
       - openjpeg=2.5.0=hfec8fc6_2
-      - openssl=1.1.1s=h0b41bf4_1
-      - pandas=1.5.2=py39h4661b88_0
+      - openssl=3.0.7=h0b41bf4_2
+      - pandas=1.5.3=py39h2ad29b5_0
       - pandoc=2.19.2=h32600fe_1
-      - pcre2=10.40=hc3806b6_0
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39h2320bf1_4
+      - pillow=9.4.0=py39ha08a7e4_0
       - pluggy=1.0.0=py39hf3d152e_4
       - psutil=5.9.4=py39hb9d737c_0
       - pthread-stubs=0.4=h36c2ea0_1001
-      - pyqt-impl=5.12.3=py39hde8b62d_8
-      - pyqt5-sip=4.19.18=py39he80948d_8
-      - pyqt=5.12.3=py39hf3d152e_8
-      - pyqtchart=5.12=py39h0fcd23e_8
-      - pyqtwebengine=5.12.1=py39h0fcd23e_8
-      - pyrsistent=0.19.2=py39hb9d737c_0
+      - pyrsistent=0.19.3=py39h72bdee0_0
       - pysocks=1.7.1=py39hf3d152e_5
-      - pytest=7.2.0=py39hf3d152e_1
-      - python=3.9.15=h47a2c10_0_cpython
+      - python=3.9.15=hba424b6_0_cpython
       - pyyaml=6.0=py39hb9d737c_5
-      - pyzmq=24.0.1=py39headdf64_1
-      - qt=5.12.9=h1304e3e_6
+      - pyzmq=25.0.0=py39h0be026e_0
       - readline=8.1.2=h0f457ee_0
-      - scipy=1.9.3=py39hddc5342_2
-      - sqlite=3.40.0=h4ff8645_0
+      - scipy=1.10.0=py39h7360e5f_0
       - terminado=0.17.1=pyh41d4057_0
       - tk=8.6.12=h27826a3_0
       - tornado=6.2=py39hb9d737c_1
-      - unicodedata2=15.0.0=py39hb9d737c_0
       - xorg-libxau=1.0.9=h7f98852_0
       - xorg-libxdmcp=1.1.3=h7f98852_0
       - xz=5.2.6=h166bdaf_0
       - yaml=0.2.5=h7f98852_2
       - zeromq=4.3.4=h9c3ff4c_1
       - zlib=1.2.13=h166bdaf_4
-      - zstd=1.5.2=h6239696_4
+      - zstd=1.5.2=h3eb15da_6
       osx-64:
       - argon2-cffi-bindings=21.2.0=py39ha30fb19_3
       - bokeh=2.4.3=py39h6e9494a_0
@@ -311,24 +273,25 @@ env_specs:
       - cffi=1.15.1=py39h131948b_3
       - cftime=1.6.2=py39h7cc1f47_1
       - click=8.1.3=py39h6e9494a_1
-      - contourpy=1.0.6=py39h92daf61_0
+      - contourpy=1.0.7=py39h92daf61_0
       - cramjam=2.6.2=py39hd4bc93a_0
-      - cryptography=38.0.4=py39hbeae22c_0
+      - cryptography=39.0.0=py39hbeae22c_0
       - curl=7.87.0=h6df9250_0
       - cytoolz=0.12.0=py39ha30fb19_1
-      - debugpy=1.6.4=py39h7a8716b_0
-      - fastparquet=2022.12.0=py39h7cc1f47_0
+      - debugpy=1.6.6=py39h7a8716b_0
+      - fastparquet=2023.1.0=py39h7cc1f47_0
       - fonttools=4.38.0=py39ha30fb19_1
       - freetype=2.12.1=h3f81eb7_1
       - hdf4=4.2.15=h7aa5921_5
-      - hdf5=1.12.2=nompi_h1f71328_100
+      - hdf5=1.12.2=nompi_h48135f9_101
       - icu=70.1=h96cf925_0
       - jpeg=9e=hac89ed1_2
-      - jupyter_core=5.1.0=py39h6e9494a_0
+      - jupyter_core=5.1.5=py39h6e9494a_0
       - kiwisolver=1.4.4=py39h92daf61_1
       - krb5=1.20.1=h049b76e_0
       - lcms2=2.14=h29502cd_1
       - lerc=4.0.0=hb486fe8_0
+      - libaec=1.0.6=hf0c8a7f_1
       - libblas=3.9.0=16_osx64_openblas
       - libbrotlicommon=1.0.9=hb7f2c08_8
       - libbrotlidec=1.0.9=hb7f2c08_8
@@ -336,57 +299,57 @@ env_specs:
       - libcblas=3.9.0=16_osx64_openblas
       - libcurl=7.87.0=h6df9250_0
       - libcxx=14.0.6=hccf4f1f_0
-      - libdeflate=1.14=hb7f2c08_0
+      - libdeflate=1.17=hac1461d_0
       - libedit=3.1.20191231=h0678c8f_2
       - libev=4.33=haf1e3a3_1
       - libffi=3.4.2=h0d85af4_5
       - libgfortran5=11.3.0=h082f757_27
       - libgfortran=5.0.0=11_3_0_h97931a8_27
       - libiconv=1.17=hac89ed1_0
+      - libjpeg-turbo=2.1.4=hb7f2c08_0
       - liblapack=3.9.0=16_osx64_openblas
       - libllvm11=11.1.0=h8fb7429_5
       - libnetcdf=4.8.1=nompi_hc61b76e_106
-      - libnghttp2=1.47.0=h5aae05b_1
+      - libnghttp2=1.51.0=he2ab024_0
       - libopenblas=0.3.21=openmp_h429af6e_3
       - libpng=1.6.39=ha978bb4_0
       - libsodium=1.0.18=hbcb3906_1
       - libsqlite=3.40.0=ha978bb4_0
       - libssh2=1.10.0=h47af595_3
-      - libtiff=4.5.0=h6268bbc_0
+      - libtiff=4.5.0=hee9004a_2
       - libwebp-base=1.2.4=h775f41a_0
       - libxcb=1.13=h0d85af4_1004
       - libxml2=2.10.3=hb9e07b5_0
       - libzip=1.9.2=h6db710c_1
       - libzlib=1.2.13=hfd90126_4
-      - llvm-openmp=15.0.6=h61d9ccf_0
+      - llvm-openmp=15.0.7=h61d9ccf_0
       - llvmlite=0.39.1=py39had167e2_1
-      - lz4-c=1.9.3=he49afe7_1
-      - lz4=4.0.2=py39hd0af75a_0
-      - markupsafe=2.1.1=py39ha30fb19_2
-      - matplotlib-base=3.6.2=py39hb2f573b_0
-      - matplotlib=3.6.2=py39h6e9494a_0
+      - lz4-c=1.9.4=hf0c8a7f_0
+      - lz4=4.2.0=py39hd0af75a_0
+      - markupsafe=2.1.2=py39ha30fb19_0
+      - matplotlib-base=3.6.3=py39hb2f573b_0
+      - matplotlib=3.6.3=py39h6e9494a_0
       - msgpack-python=1.0.4=py39h92daf61_1
       - ncurses=6.3=h96cf925_1
       - netcdf4=1.6.2=nompi_py39h0d363ce_100
       - numba=0.56.4=py39hf6b9d82_0
       - numpy=1.23.5=py39hdfa1d0c_0
       - openjpeg=2.5.0=h13ac156_2
-      - openssl=3.0.7=hfd90126_1
-      - pandas=1.5.2=py39hecff1ad_0
+      - openssl=3.0.7=hfd90126_2
+      - pandas=1.5.3=py39hecff1ad_0
       - pandoc=2.19.2=h694c41f_1
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39h7f5cd59_4
+      - pillow=9.4.0=py39h193cfb4_0
       - pluggy=1.0.0=py39h6e9494a_4
       - psutil=5.9.4=py39ha30fb19_0
       - pthread-stubs=0.4=hc929b4f_1001
-      - pyrsistent=0.19.2=py39ha30fb19_0
+      - pyrsistent=0.19.3=py39ha30fb19_0
       - pysocks=1.7.1=py39h6e9494a_5
-      - pytest=7.2.0=py39h6e9494a_1
       - python=3.9.15=h709bd14_0_cpython
       - pyyaml=6.0=py39ha30fb19_5
-      - pyzmq=24.0.1=py39hed8f129_1
+      - pyzmq=25.0.0=py39hed8f129_0
       - readline=8.1.2=h3899abd_0
-      - scipy=1.9.3=py39h8a15683_2
+      - scipy=1.10.0=py39h8a15683_0
       - tk=8.6.12=h5dbffcc_0
       - tornado=6.2=py39ha30fb19_1
       - unicodedata2=15.0.0=py39ha30fb19_0
@@ -396,7 +359,7 @@ env_specs:
       - yaml=0.2.5=h0d85af4_2
       - zeromq=4.3.4=he49afe7_1
       - zlib=1.2.13=hfd90126_4
-      - zstd=1.5.2=hfa58983_4
+      - zstd=1.5.2=hbc0c0cd_6
       osx-arm64:
       - argon2-cffi-bindings=21.2.0=py39h02fc5c5_3
       - bokeh=2.4.3=py39h2804cbe_0
@@ -409,24 +372,25 @@ env_specs:
       - cffi=1.15.1=py39h7e6b969_3
       - cftime=1.6.2=py39h4d8bf0d_1
       - click=8.1.3=py39h2804cbe_1
-      - contourpy=1.0.6=py39haaf3ac1_0
+      - contourpy=1.0.7=py39haaf3ac1_0
       - cramjam=2.6.2=py39hb39fadb_0
-      - cryptography=38.0.4=py39he2a39a8_0
+      - cryptography=39.0.0=py39he2a39a8_0
       - curl=7.87.0=h9049daf_0
       - cytoolz=0.12.0=py39h02fc5c5_1
-      - debugpy=1.6.4=py39h23fbdae_0
-      - fastparquet=2022.12.0=py39h4d8bf0d_0
+      - debugpy=1.6.6=py39h23fbdae_0
+      - fastparquet=2023.1.0=py39h4d8bf0d_0
       - fonttools=4.38.0=py39h02fc5c5_1
       - freetype=2.12.1=hd633e50_1
       - hdf4=4.2.15=h1a38d6a_5
-      - hdf5=1.12.2=nompi_h33dac16_100
+      - hdf5=1.12.2=nompi_ha7af310_101
       - icu=70.1=h6b3803e_0
       - jpeg=9e=he4db4b2_2
-      - jupyter_core=5.1.0=py39h2804cbe_0
+      - jupyter_core=5.1.5=py39h2804cbe_0
       - kiwisolver=1.4.4=py39haaf3ac1_1
       - krb5=1.20.1=h69eda48_0
       - lcms2=2.14=h481adae_1
       - lerc=4.0.0=h9a09cb3_0
+      - libaec=1.0.6=hb7217d7_1
       - libblas=3.9.0=16_osxarm64_openblas
       - libbrotlicommon=1.0.9=h1a8c8d9_8
       - libbrotlidec=1.0.9=h1a8c8d9_8
@@ -434,57 +398,57 @@ env_specs:
       - libcblas=3.9.0=16_osxarm64_openblas
       - libcurl=7.87.0=h9049daf_0
       - libcxx=14.0.6=h2692d47_0
-      - libdeflate=1.14=h1a8c8d9_0
+      - libdeflate=1.17=h1a8c8d9_0
       - libedit=3.1.20191231=hc8eb9b7_2
       - libev=4.33=h642e427_1
       - libffi=3.4.2=h3422bc3_5
       - libgfortran5=11.3.0=hdaf2cc0_27
       - libgfortran=5.0.0=11_3_0_hd922786_27
       - libiconv=1.17=he4db4b2_0
+      - libjpeg-turbo=2.1.4=h1a8c8d9_0
       - liblapack=3.9.0=16_osxarm64_openblas
       - libllvm11=11.1.0=hfa12f05_5
       - libnetcdf=4.8.1=nompi_h2510be2_106
-      - libnghttp2=1.47.0=h519802c_1
+      - libnghttp2=1.51.0=hae82a92_0
       - libopenblas=0.3.21=openmp_hc731615_3
       - libpng=1.6.39=h76d750c_0
       - libsodium=1.0.18=h27ca646_1
       - libsqlite=3.40.0=h76d750c_0
       - libssh2=1.10.0=h7a5bd25_3
-      - libtiff=4.5.0=heb92581_0
+      - libtiff=4.5.0=h5dffbdd_2
       - libwebp-base=1.2.4=h57fd34a_0
       - libxcb=1.13=h9b22ae9_1004
       - libxml2=2.10.3=h87b0503_0
       - libzip=1.9.2=h76ab92c_1
       - libzlib=1.2.13=h03a7124_4
-      - llvm-openmp=15.0.6=h7cfbb63_0
+      - llvm-openmp=15.0.7=h7cfbb63_0
       - llvmlite=0.39.1=py39h8ca5d33_1
-      - lz4-c=1.9.3=hbdafb3b_1
-      - lz4=4.0.2=py39hb35ce34_0
-      - markupsafe=2.1.1=py39h02fc5c5_2
-      - matplotlib-base=3.6.2=py39h35e9e80_0
-      - matplotlib=3.6.2=py39hdf13c20_0
+      - lz4-c=1.9.4=hb7217d7_0
+      - lz4=4.2.0=py39hb35ce34_0
+      - markupsafe=2.1.2=py39h02fc5c5_0
+      - matplotlib-base=3.6.3=py39h35e9e80_0
+      - matplotlib=3.6.3=py39hdf13c20_0
       - msgpack-python=1.0.4=py39haaf3ac1_1
       - ncurses=6.3=h07bb92c_1
       - netcdf4=1.6.2=nompi_py39h8ded8ba_100
       - numba=0.56.4=py39h251cc7c_0
       - numpy=1.23.5=py39hefdcf20_0
       - openjpeg=2.5.0=hbc2ba62_2
-      - openssl=3.0.7=h03a7124_1
-      - pandas=1.5.2=py39hde7b980_0
+      - openssl=3.0.7=h03a7124_2
+      - pandas=1.5.3=py39hde7b980_0
       - pandoc=2.19.2=hce30654_1
       - pickleshare=0.7.5=py_1003
-      - pillow=9.2.0=py39h8bd98a6_4
+      - pillow=9.4.0=py39h8bbe137_0
       - pluggy=1.0.0=py39h2804cbe_4
       - psutil=5.9.4=py39h02fc5c5_0
       - pthread-stubs=0.4=h27ca646_1001
-      - pyrsistent=0.19.2=py39h02fc5c5_0
+      - pyrsistent=0.19.3=py39h02fc5c5_0
       - pysocks=1.7.1=py39h2804cbe_5
-      - pytest=7.2.0=py39h2804cbe_1
       - python=3.9.15=hea58f1e_0_cpython
       - pyyaml=6.0=py39h02fc5c5_5
-      - pyzmq=24.0.1=py39h0553236_1
+      - pyzmq=25.0.0=py39h0553236_0
       - readline=8.1.2=h46ed386_0
-      - scipy=1.9.3=py39h18313fe_2
+      - scipy=1.10.0=py39h18313fe_0
       - tk=8.6.12=he1e0b03_0
       - tornado=6.2=py39h02fc5c5_1
       - unicodedata2=15.0.0=py39h02fc5c5_0
@@ -494,7 +458,7 @@ env_specs:
       - yaml=0.2.5=h3422bc3_2
       - zeromq=4.3.4=hbdafb3b_1
       - zlib=1.2.13=h03a7124_4
-      - zstd=1.5.2=h8128057_4
+      - zstd=1.5.2=hf913c23_6
       win-64:
       - argon2-cffi-bindings=21.2.0=py39ha55989b_3
       - bokeh=2.4.3=py39hcbf5309_0
@@ -506,13 +470,13 @@ env_specs:
       - cffi=1.15.1=py39h68f70e3_3
       - cftime=1.6.2=py39hc266a54_1
       - click=8.1.3=py39hcbf5309_1
-      - contourpy=1.0.6=py39h1f6ef14_0
+      - contourpy=1.0.7=py39h1f6ef14_0
       - cramjam=2.6.2=py39h424382f_0
-      - cryptography=38.0.4=py39hb6bd5e6_0
+      - cryptography=39.0.0=py39hb6bd5e6_0
       - curl=7.87.0=h68f0423_0
       - cytoolz=0.12.0=py39ha55989b_1
-      - debugpy=1.6.4=py39h99910a6_0
-      - fastparquet=2022.12.0=py39hc266a54_0
+      - debugpy=1.6.6=py39h99910a6_0
+      - fastparquet=2023.1.0=py39hc266a54_0
       - fonttools=4.38.0=py39ha55989b_1
       - freetype=2.12.1=h546665d_1
       - gettext=0.21.1=h5728263_0
@@ -521,30 +485,32 @@ env_specs:
       - gst-plugins-base=1.21.3=h001b923_1
       - gstreamer=1.21.3=h6b5321d_1
       - hdf4=4.2.15=h1b1b6ef_5
-      - hdf5=1.12.2=nompi_h57737ce_100
+      - hdf5=1.12.2=nompi_h57737ce_101
       - icu=70.1=h0e60522_0
       - intel-openmp=2023.0.0=h57928b3_25922
-      - ipykernel=6.19.4=pyh025b116_0
-      - ipython=8.7.0=pyh08f2357_0
+      - ipykernel=6.20.2=pyh025b116_0
+      - ipython=8.9.0=pyh08f2357_0
       - jpeg=9e=h8ffe710_2
-      - jupyter_core=5.1.0=py39hcbf5309_0
+      - jupyter_core=5.1.5=py39hcbf5309_0
       - kiwisolver=1.4.4=py39h1f6ef14_1
       - krb5=1.20.1=heb0366b_0
       - lcms2=2.14=ha5c8aab_1
       - lerc=4.0.0=h63175ca_0
+      - libaec=1.0.6=h63175ca_1
       - libblas=3.9.0=16_win64_mkl
       - libbrotlicommon=1.0.9=hcfcfb64_8
       - libbrotlidec=1.0.9=hcfcfb64_8
       - libbrotlienc=1.0.9=hcfcfb64_8
       - libcblas=3.9.0=16_win64_mkl
-      - libclang13=15.0.6=default_h77d9078_0
-      - libclang=15.0.6=default_h77d9078_0
+      - libclang13=15.0.7=default_h77d9078_0
+      - libclang=15.0.7=default_h77d9078_0
       - libcurl=7.87.0=h68f0423_0
-      - libdeflate=1.14=hcfcfb64_0
+      - libdeflate=1.17=hcfcfb64_0
       - libffi=3.4.2=h8ffe710_5
       - libglib=2.74.1=he8f3873_1
       - libhwloc=2.8.0=h039e092_1
       - libiconv=1.17=h8ffe710_0
+      - libjpeg-turbo=2.1.4=hcfcfb64_0
       - liblapack=3.9.0=16_win64_mkl
       - libnetcdf=4.8.1=nompi_h8c042bf_106
       - libogg=1.3.4=h8ffe710_1
@@ -552,7 +518,7 @@ env_specs:
       - libsodium=1.0.18=h8d14728_1
       - libsqlite=3.40.0=hcfcfb64_0
       - libssh2=1.10.0=h9a1e1f7_3
-      - libtiff=4.5.0=hc4f729c_0
+      - libtiff=4.5.0=hf8721a0_2
       - libvorbis=1.3.7=h0e60522_0
       - libwebp-base=1.2.4=h8ffe710_0
       - libxcb=1.13=hcd874cb_1004
@@ -560,47 +526,47 @@ env_specs:
       - libzip=1.9.2=h519de47_1
       - libzlib=1.2.13=hcfcfb64_4
       - llvmlite=0.39.1=py39hd28a505_1
-      - lz4-c=1.9.3=h8ffe710_1
-      - lz4=4.0.2=py39hf617134_0
+      - lz4-c=1.9.4=hcfcfb64_0
+      - lz4=4.2.0=py39hf617134_0
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
       - m2w64-gmp=6.1.0=2
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
-      - markupsafe=2.1.1=py39ha55989b_2
-      - matplotlib-base=3.6.2=py39haf65ace_0
-      - matplotlib=3.6.2=py39hcbf5309_0
+      - markupsafe=2.1.2=py39ha55989b_0
+      - matplotlib-base=3.6.3=py39haf65ace_0
+      - matplotlib=3.6.3=py39hcbf5309_0
       - mkl=2022.1.0=h6a75c08_874
       - msgpack-python=1.0.4=py39h1f6ef14_1
       - msys2-conda-epoch=20160418=1
+      - munkres=1.1.4=pyh9f0ad1d_0
       - netcdf4=1.6.2=nompi_py39h34fa13a_100
       - numba=0.56.4=py39h99ae161_0
       - numpy=1.23.5=py39hbccbffa_0
       - openjpeg=2.5.0=ha2aaf27_2
-      - openssl=3.0.7=hcfcfb64_1
-      - pandas=1.5.2=py39h2ba5b7c_0
+      - openssl=3.0.7=hcfcfb64_2
+      - pandas=1.5.3=py39h2ba5b7c_0
       - pandoc=2.19.2=h57928b3_1
       - pcre2=10.40=h17e33f8_0
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39hcebd2be_4
+      - pillow=9.4.0=py39h9767c21_0
       - pluggy=1.0.0=py39hcbf5309_4
       - ply=3.11=py_1
       - psutil=5.9.4=py39ha55989b_0
       - pthread-stubs=0.4=hcd874cb_1001
       - pthreads-win32=2.9.1=hfa6e2cd_3
-      - pyqt5-sip=12.11.0=py39h99910a6_2
-      - pyqt=5.15.7=py39hb77abff_2
-      - pyrsistent=0.19.2=py39ha55989b_0
+      - pyqt5-sip=12.11.0=py39h99910a6_3
+      - pyqt=5.15.7=py39hb77abff_3
+      - pyrsistent=0.19.3=py39ha55989b_0
       - pysocks=1.7.1=py39hcbf5309_5
-      - pytest=7.2.0=py39hcbf5309_1
       - python=3.9.15=h4de0772_0_cpython
       - pywin32=304=py39h99910a6_2
-      - pywinpty=2.0.9=py39h99910a6_0
+      - pywinpty=2.0.10=py39h99910a6_0
       - pyyaml=6.0=py39ha55989b_5
-      - pyzmq=24.0.1=py39hea35a22_1
-      - qt-main=5.15.6=h9580fe5_5
-      - scipy=1.9.3=py39hfbf2dce_2
-      - sip=6.7.5=py39h99910a6_0
+      - pyzmq=25.0.0=py39hea35a22_0
+      - qt-main=5.15.6=h9580fe5_6
+      - scipy=1.10.0=py39hfbf2dce_0
+      - sip=6.7.6=py39h99910a6_0
       - tbb=2021.7.0=h91493d7_1
       - terminado=0.17.0=pyh08f2357_0
       - tk=8.6.12=h8ffe710_0
@@ -608,8 +574,8 @@ env_specs:
       - tornado=6.2=py39ha55989b_1
       - ucrt=10.0.22621.0=h57928b3_0
       - unicodedata2=15.0.0=py39ha55989b_0
-      - vc=14.3=h3d8a991_9
-      - vs2015_runtime=14.32.31332=h1d6e394_9
+      - vc=14.3=hb6edc58_10
+      - vs2015_runtime=14.34.31931=h4c5c07a_10
       - win_inet_pton=1.1.0=py39hcbf5309_5
       - winpty=0.4.3=4
       - xorg-libxau=1.0.9=hcd874cb_0
@@ -618,7 +584,7 @@ env_specs:
       - yaml=0.2.5=h8ffe710_2
       - zeromq=4.3.4=h0e60522_1
       - zlib=1.2.13=hcfcfb64_4
-      - zstd=1.5.2=h7755175_4
+      - zstd=1.5.2=h12be248_6
   doc:
     locked: true
     env_spec_hash: af37b5f49fc6625f1e03c091943fcf0d24dd1a5c
@@ -629,61 +595,61 @@ env_specs:
     - win-64
     packages:
       all:
-      - _ipython_minor_entry_point=8.7.0=h8cf3c4a_0
-      - alabaster=0.7.12=py_0
+      - alabaster=0.7.13=pyhd8ed1ab_0
       - anyio=3.6.2=pyhd8ed1ab_0
+      - appdirs=1.4.4=pyh9f0ad1d_0
       - argon2-cffi=21.3.0=pyhd8ed1ab_0
       - asttokens=2.2.1=pyhd8ed1ab_0
-      - attrs=22.1.0=pyh71513ae_1
+      - attrs=22.2.0=pyh71513ae_0
       - babel=2.11.0=pyhd8ed1ab_0
       - backcall=0.2.0=pyh9f0ad1d_0
       - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
       - backports=1.0=pyhd8ed1ab_3
       - beautifulsoup4=4.11.1=pyha770c72_0
-      - bleach=5.0.1=pyhd8ed1ab_0
+      - bleach=6.0.0=pyhd8ed1ab_0
       - certifi=2022.12.7=pyhd8ed1ab_0
       - charset-normalizer=2.1.1=pyhd8ed1ab_0
-      - cloudpickle=2.2.0=pyhd8ed1ab_0
+      - cloudpickle=2.2.1=pyhd8ed1ab_0
       - colorama=0.4.6=pyhd8ed1ab_0
       - colorcet=3.0.1=py_0
       - comm=0.1.2=pyhd8ed1ab_0
       - cycler=0.11.0=pyhd8ed1ab_0
-      - dask-core=2022.12.1=pyhd8ed1ab_0
-      - dask=2022.12.1=pyhd8ed1ab_0
+      - dask-core=2023.1.1=pyhd8ed1ab_0
+      - dask=2023.1.1=pyhd8ed1ab_0
       - datashader=0.14.1=py_0
       - datashape=0.5.4=py_1
       - decorator=5.1.1=pyhd8ed1ab_0
       - defusedxml=0.7.1=pyhd8ed1ab_0
-      - distributed=2022.12.1=pyhd8ed1ab_0
+      - distributed=2023.1.1=pyhd8ed1ab_0
       - entrypoints=0.4=pyhd8ed1ab_0
       - executing=1.2.0=pyhd8ed1ab_0
       - flit-core=3.8.0=pyhd8ed1ab_0
-      - fsspec=2022.11.0=pyhd8ed1ab_0
+      - fsspec=2023.1.0=pyhd8ed1ab_0
       - heapdict=1.0.1=py_0
       - holoviews=1.15.0=py_0
       - hvplot=0.8.0=py_0
       - idna=3.4=pyhd8ed1ab_0
       - imagesize=1.4.1=pyhd8ed1ab_0
-      - importlib-metadata=5.2.0=pyha770c72_0
-      - importlib_resources=5.10.1=pyhd8ed1ab_0
+      - importlib-metadata=6.0.0=pyha770c72_0
+      - importlib_resources=5.10.2=pyhd8ed1ab_0
       - ipympl=0.9.2=pyhd8ed1ab_0
       - ipython_genutils=0.2.0=py_1
-      - ipywidgets=7.7.2=pyhd8ed1ab_0
+      - ipywidgets=8.0.4=pyhd8ed1ab_0
       - jedi=0.18.2=pyhd8ed1ab_0
       - jinja2=3.1.2=pyhd8ed1ab_1
       - json5=0.9.5=pyh9f0ad1d_0
       - jsonschema=4.17.3=pyhd8ed1ab_0
       - jupyter-cache=0.5.0=pyhd8ed1ab_0
-      - jupyter_client=7.4.8=pyhd8ed1ab_0
+      - jupyter_client=7.4.9=pyhd8ed1ab_0
       - jupyter_contrib_core=0.4.0=pyhd8ed1ab_0
-      - jupyter_events=0.5.0=pyhd8ed1ab_0
+      - jupyter_events=0.6.3=pyhd8ed1ab_0
       - jupyter_nbextensions_configurator=0.6.1=pyhd8ed1ab_0
-      - jupyter_server=2.0.2=pyhd8ed1ab_0
-      - jupyter_server_terminals=0.4.3=pyhd8ed1ab_0
-      - jupyterlab=3.5.2=pyhd8ed1ab_0
+      - jupyter_server=2.1.0=pyhd8ed1ab_0
+      - jupyter_server_terminals=0.4.4=pyhd8ed1ab_1
+      - jupyterlab=3.5.3=pyhd8ed1ab_0
       - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
-      - jupyterlab_server=2.16.5=pyhd8ed1ab_0
-      - jupyterlab_widgets=1.1.1=pyhd8ed1ab_0
+      - jupyterlab_server=2.19.0=pyhd8ed1ab_0
+      - jupyterlab_widgets=3.0.5=pyhd8ed1ab_0
       - locket=1.0.0=pyhd8ed1ab_0
       - markdown-it-py=2.1.0=pyhd8ed1ab_0
       - markdown=3.4.1=pyhd8ed1ab_0
@@ -696,15 +662,15 @@ env_specs:
       - myst-parser=0.18.1=pyhd8ed1ab_0
       - nbclassic=0.4.8=pyhd8ed1ab_0
       - nbclient=0.5.13=pyhd8ed1ab_0
-      - nbconvert-core=7.2.7=pyhd8ed1ab_0
-      - nbconvert-pandoc=7.2.7=pyhd8ed1ab_0
-      - nbconvert=7.2.7=pyhd8ed1ab_0
-      - nbformat=5.7.1=pyhd8ed1ab_0
-      - nbsite=0.8.0rc5=py_0
+      - nbconvert-core=7.2.9=pyhd8ed1ab_0
+      - nbconvert-pandoc=7.2.9=pyhd8ed1ab_0
+      - nbconvert=7.2.9=pyhd8ed1ab_0
+      - nbformat=5.7.3=pyhd8ed1ab_0
+      - nbsite=0.8.0rc7=py_0
       - nest-asyncio=1.5.6=pyhd8ed1ab_0
       - notebook-shim=0.2.2=pyhd8ed1ab_0
       - notebook=6.5.2=pyha770c72_1
-      - packaging=22.0=pyhd8ed1ab_0
+      - packaging=23.0=pyhd8ed1ab_0
       - pandocfilters=1.5.0=pyhd8ed1ab_0
       - panel=0.13.1=py_0
       - param=1.12.2=py_0
@@ -712,27 +678,30 @@ env_specs:
       - partd=1.3.0=pyhd8ed1ab_0
       - pip=22.3.1=pyhd8ed1ab_0
       - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
-      - platformdirs=2.6.0=pyhd8ed1ab_0
-      - plotly=5.11.0=pyhd8ed1ab_1
-      - prometheus_client=0.15.0=pyhd8ed1ab_0
+      - platformdirs=2.6.2=pyhd8ed1ab_0
+      - plotly=5.13.0=pyhd8ed1ab_0
+      - pooch=1.6.0=pyhd8ed1ab_0
+      - prometheus_client=0.16.0=pyhd8ed1ab_0
       - prompt-toolkit=3.0.36=pyha770c72_0
       - pure_eval=0.2.2=pyhd8ed1ab_0
       - pycparser=2.21=pyhd8ed1ab_0
       - pyct-core=0.4.8=py_0
       - pyct=0.4.8=py_0
       - pydata-sphinx-theme=0.8.1=pyhd8ed1ab_0
-      - pygments=2.13.0=pyhd8ed1ab_0
-      - pyopenssl=22.1.0=pyhd8ed1ab_0
+      - pygments=2.14.0=pyhd8ed1ab_0
+      - pyopenssl=23.0.0=pyhd8ed1ab_0
       - pyparsing=3.0.9=pyhd8ed1ab_0
       - python-dateutil=2.8.2=pyhd8ed1ab_0
       - python-fastjsonschema=2.16.2=pyhd8ed1ab_0
-      - python-json-logger=2.0.1=pyh9f0ad1d_0
+      - python-json-logger=2.0.4=pyhd8ed1ab_0
       - python_abi=3.9=3_cp39
-      - pytz=2022.7=pyhd8ed1ab_0
+      - pytz=2022.7.1=pyhd8ed1ab_0
       - pyviz_comms=2.2.1=py_0
-      - requests=2.28.1=pyhd8ed1ab_1
+      - requests=2.28.2=pyhd8ed1ab_0
+      - rfc3339-validator=0.1.4=pyhd8ed1ab_0
+      - rfc3986-validator=0.1.1=pyh9f0ad1d_0
       - send2trash=1.8.0=pyhd8ed1ab_0
-      - setuptools=65.6.3=pyhd8ed1ab_0
+      - setuptools=66.1.1=pyhd8ed1ab_0
       - six=1.16.0=pyh6c4a22f_0
       - sniffio=1.3.0=pyhd8ed1ab_0
       - snowballstemmer=2.2.0=pyhd8ed1ab_0
@@ -740,7 +709,7 @@ env_specs:
       - soupsieve=2.3.2.post1=pyhd8ed1ab_0
       - sphinx-design=0.3.0=pyhd8ed1ab_0
       - sphinx=5.3.0=pyhd8ed1ab_0
-      - sphinxcontrib-applehelp=1.0.2=py_0
+      - sphinxcontrib-applehelp=1.0.4=pyhd8ed1ab_0
       - sphinxcontrib-devhelp=1.0.2=py_0
       - sphinxcontrib-htmlhelp=2.0.0=pyhd8ed1ab_0
       - sphinxcontrib-jsmath=1.0.1=py_0
@@ -754,26 +723,26 @@ env_specs:
       - tomli=2.0.1=pyhd8ed1ab_0
       - toolz=0.12.0=pyhd8ed1ab_0
       - tqdm=4.64.1=pyhd8ed1ab_0
-      - traitlets=5.8.0=pyhd8ed1ab_0
+      - traitlets=5.8.1=pyhd8ed1ab_0
       - typing-extensions=4.4.0=hd8ed1ab_0
       - typing_extensions=4.4.0=pyha770c72_0
       - tzdata=2022g=h191b570_0
-      - urllib3=1.26.13=pyhd8ed1ab_0
-      - wcwidth=0.2.5=pyh9f0ad1d_2
+      - urllib3=1.26.14=pyhd8ed1ab_0
+      - wcwidth=0.2.6=pyhd8ed1ab_0
       - webencodings=0.5.1=py_1
-      - websocket-client=1.4.2=pyhd8ed1ab_0
+      - websocket-client=1.5.0=pyhd8ed1ab_0
       - wheel=0.38.4=pyhd8ed1ab_0
-      - widgetsnbextension=3.6.1=pyha770c72_0
-      - xarray=2022.12.0=pyhd8ed1ab_0
+      - widgetsnbextension=4.0.5=pyhd8ed1ab_0
+      - xarray=2023.1.0=pyhd8ed1ab_0
       - zict=2.2.0=pyhd8ed1ab_0
-      - zipp=3.11.0=pyhd8ed1ab_0
+      - zipp=3.12.0=pyhd8ed1ab_0
       unix:
       - pexpect=4.8.0=pyh1a96a4e_2
       - ptyprocess=0.7.0=pyhd3deb0d_0
       osx:
       - appnope=0.1.3=pyhd8ed1ab_0
-      - ipykernel=6.19.4=pyh736e0ef_0
-      - ipython=8.7.0=pyhd1c38e8_0
+      - ipykernel=6.20.2=pyh736e0ef_0
+      - ipython=8.9.0=pyhd1c38e8_0
       - munkres=1.1.4=pyh9f0ad1d_0
       - terminado=0.17.1=pyhd1c38e8_0
       linux-64:
@@ -789,31 +758,32 @@ env_specs:
       - cftime=1.6.2=py39h2ae25f5_1
       - click=8.1.3=py39hf3d152e_1
       - cramjam=2.6.2=py39h4ef89ea_0
-      - cryptography=38.0.4=py39h3ccb8fc_0
+      - cryptography=39.0.0=py39h079d5ae_0
       - curl=7.87.0=hdc1c0ab_0
       - cytoolz=0.12.0=py39hb9d737c_1
-      - debugpy=1.6.4=py39h5a03fae_0
+      - debugpy=1.6.6=py39h227be39_0
       - docutils=0.16=py39hf3d152e_3
-      - fastparquet=2022.12.0=py39h389d5f1_0
+      - fastparquet=2023.1.0=py39h389d5f1_0
       - freetype=2.12.1=hca18f0e_1
-      - greenlet=2.0.1=py39h5a03fae_0
+      - greenlet=2.0.2=py39h227be39_0
       - hdf4=4.2.15=h9772cbc_5
-      - hdf5=1.12.2=nompi_h4df4325_100
+      - hdf5=1.12.2=nompi_h4df4325_101
       - icu=70.1=h27087fc_0
-      - ipykernel=6.19.4=pyh210e3f2_0
-      - ipython=8.7.0=pyh41d4057_0
+      - ipykernel=6.20.2=pyh210e3f2_0
+      - ipython=8.9.0=pyh41d4057_0
       - jpeg=9e=h166bdaf_2
-      - jupyter_core=5.1.0=py39hf3d152e_0
+      - jupyter_core=5.1.5=py39hf3d152e_0
       - keyutils=1.6.1=h166bdaf_0
       - kiwisolver=1.4.4=py39hf939315_1
       - krb5=1.20.1=h81ceb04_0
       - lcms2=2.14=hfd0df8a_1
-      - ld_impl_linux-64=2.39=hcc3a1bd_1
+      - ld_impl_linux-64=2.40=h41732ed_0
       - lerc=4.0.0=h27087fc_0
+      - libaec=1.0.6=hcb278e6_1
       - libblas=3.9.0=16_linux64_openblas
       - libcblas=3.9.0=16_linux64_openblas
       - libcurl=7.87.0=hdc1c0ab_0
-      - libdeflate=1.14=h166bdaf_0
+      - libdeflate=1.17=h0b41bf4_0
       - libedit=3.1.20191231=he28a2e2_2
       - libev=4.33=h516909a_1
       - libffi=3.4.2=h7f98852_5
@@ -822,10 +792,11 @@ env_specs:
       - libgfortran5=12.2.0=h337968e_19
       - libgomp=12.2.0=h65d4601_19
       - libiconv=1.17=h166bdaf_0
+      - libjpeg-turbo=2.1.4=h166bdaf_0
       - liblapack=3.9.0=16_linux64_openblas
       - libllvm11=11.1.0=he0ac6c6_5
       - libnetcdf=4.8.1=nompi_h261ec11_106
-      - libnghttp2=1.47.0=hff17c54_1
+      - libnghttp2=1.51.0=hff17c54_0
       - libnsl=2.0.0=h7f98852_0
       - libopenblas=0.3.21=pthreads_h78a6416_3
       - libpng=1.6.39=h753d276_0
@@ -833,7 +804,7 @@ env_specs:
       - libsqlite=3.40.0=h753d276_0
       - libssh2=1.10.0=hf14f497_3
       - libstdcxx-ng=12.2.0=h46fd767_19
-      - libtiff=4.5.0=h82bc61c_0
+      - libtiff=4.5.0=h6adf6a1_2
       - libuuid=2.32.1=h7f98852_1000
       - libwebp-base=1.2.4=h166bdaf_0
       - libxcb=1.13=h7f98852_1004
@@ -841,9 +812,9 @@ env_specs:
       - libzip=1.9.2=hc929e4a_1
       - libzlib=1.2.13=h166bdaf_4
       - llvmlite=0.39.1=py39h7d9a04d_1
-      - lz4-c=1.9.3=h9c3ff4c_1
-      - lz4=4.0.2=py39h029007f_0
-      - markupsafe=2.1.1=py39hb9d737c_2
+      - lz4-c=1.9.4=hcb278e6_0
+      - lz4=4.2.0=py39h724f13c_0
+      - markupsafe=2.1.2=py39h72bdee0_0
       - matplotlib-base=3.3.2=py39h98787fa_1
       - matplotlib=3.3.2=0
       - msgpack-python=1.0.4=py39hf939315_1
@@ -852,21 +823,21 @@ env_specs:
       - numba=0.56.4=py39h61ddf18_0
       - numpy=1.23.5=py39h3d75532_0
       - openjpeg=2.5.0=hfec8fc6_2
-      - openssl=3.0.7=h0b41bf4_1
-      - pandas=1.5.2=py39h4661b88_0
+      - openssl=3.0.7=h0b41bf4_2
+      - pandas=1.5.3=py39h2ad29b5_0
       - pandoc=2.19.2=h32600fe_1
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39h2320bf1_4
+      - pillow=9.4.0=py39ha08a7e4_0
       - psutil=5.9.4=py39hb9d737c_0
       - pthread-stubs=0.4=h36c2ea0_1001
-      - pyrsistent=0.19.2=py39hb9d737c_0
+      - pyrsistent=0.19.3=py39h72bdee0_0
       - pysocks=1.7.1=py39hf3d152e_5
       - python=3.9.15=hba424b6_0_cpython
       - pyyaml=6.0=py39hb9d737c_5
-      - pyzmq=24.0.1=py39headdf64_1
+      - pyzmq=25.0.0=py39h0be026e_0
       - readline=8.1.2=h0f457ee_0
-      - scipy=1.9.3=py39hddc5342_2
-      - sqlalchemy=1.4.45=py39h72bdee0_0
+      - scipy=1.10.0=py39h7360e5f_0
+      - sqlalchemy=1.4.46=py39h72bdee0_0
       - terminado=0.17.1=pyh41d4057_0
       - tk=8.6.12=h27826a3_0
       - tornado=6.2=py39hb9d737c_1
@@ -876,7 +847,7 @@ env_specs:
       - yaml=0.2.5=h7f98852_2
       - zeromq=4.3.4=h9c3ff4c_1
       - zlib=1.2.13=h166bdaf_4
-      - zstd=1.5.2=h6239696_4
+      - zstd=1.5.2=h3eb15da_6
       osx-64:
       - argon2-cffi-bindings=21.2.0=py39ha30fb19_3
       - bokeh=2.4.3=py39h6e9494a_0
@@ -889,26 +860,27 @@ env_specs:
       - cffi=1.15.1=py39h131948b_3
       - cftime=1.6.2=py39h7cc1f47_1
       - click=8.1.3=py39h6e9494a_1
-      - contourpy=1.0.6=py39h92daf61_0
+      - contourpy=1.0.7=py39h92daf61_0
       - cramjam=2.6.2=py39hd4bc93a_0
-      - cryptography=38.0.4=py39hbeae22c_0
+      - cryptography=39.0.0=py39hbeae22c_0
       - curl=7.87.0=h6df9250_0
       - cytoolz=0.12.0=py39ha30fb19_1
-      - debugpy=1.6.4=py39h7a8716b_0
+      - debugpy=1.6.6=py39h7a8716b_0
       - docutils=0.16=py39h6e9494a_3
-      - fastparquet=2022.12.0=py39h7cc1f47_0
+      - fastparquet=2023.1.0=py39h7cc1f47_0
       - fonttools=4.38.0=py39ha30fb19_1
       - freetype=2.12.1=h3f81eb7_1
-      - greenlet=2.0.1=py39h7a8716b_0
+      - greenlet=2.0.2=py39h7a8716b_0
       - hdf4=4.2.15=h7aa5921_5
-      - hdf5=1.12.2=nompi_h1f71328_100
+      - hdf5=1.12.2=nompi_h48135f9_101
       - icu=70.1=h96cf925_0
       - jpeg=9e=hac89ed1_2
-      - jupyter_core=5.1.0=py39h6e9494a_0
+      - jupyter_core=5.1.5=py39h6e9494a_0
       - kiwisolver=1.4.4=py39h92daf61_1
       - krb5=1.20.1=h049b76e_0
       - lcms2=2.14=h29502cd_1
       - lerc=4.0.0=hb486fe8_0
+      - libaec=1.0.6=hf0c8a7f_1
       - libblas=3.9.0=16_osx64_openblas
       - libbrotlicommon=1.0.9=hb7f2c08_8
       - libbrotlidec=1.0.9=hb7f2c08_8
@@ -916,56 +888,57 @@ env_specs:
       - libcblas=3.9.0=16_osx64_openblas
       - libcurl=7.87.0=h6df9250_0
       - libcxx=14.0.6=hccf4f1f_0
-      - libdeflate=1.14=hb7f2c08_0
+      - libdeflate=1.17=hac1461d_0
       - libedit=3.1.20191231=h0678c8f_2
       - libev=4.33=haf1e3a3_1
       - libffi=3.4.2=h0d85af4_5
       - libgfortran5=11.3.0=h082f757_27
       - libgfortran=5.0.0=11_3_0_h97931a8_27
       - libiconv=1.17=hac89ed1_0
+      - libjpeg-turbo=2.1.4=hb7f2c08_0
       - liblapack=3.9.0=16_osx64_openblas
       - libllvm11=11.1.0=h8fb7429_5
       - libnetcdf=4.8.1=nompi_hc61b76e_106
-      - libnghttp2=1.47.0=h5aae05b_1
+      - libnghttp2=1.51.0=he2ab024_0
       - libopenblas=0.3.21=openmp_h429af6e_3
       - libpng=1.6.39=ha978bb4_0
       - libsodium=1.0.18=hbcb3906_1
       - libsqlite=3.40.0=ha978bb4_0
       - libssh2=1.10.0=h47af595_3
-      - libtiff=4.5.0=h6268bbc_0
+      - libtiff=4.5.0=hee9004a_2
       - libwebp-base=1.2.4=h775f41a_0
       - libxcb=1.13=h0d85af4_1004
       - libxml2=2.10.3=hb9e07b5_0
       - libzip=1.9.2=h6db710c_1
       - libzlib=1.2.13=hfd90126_4
-      - llvm-openmp=15.0.6=h61d9ccf_0
+      - llvm-openmp=15.0.7=h61d9ccf_0
       - llvmlite=0.39.1=py39had167e2_1
-      - lz4-c=1.9.3=he49afe7_1
-      - lz4=4.0.2=py39hd0af75a_0
-      - markupsafe=2.1.1=py39ha30fb19_2
-      - matplotlib-base=3.6.2=py39hb2f573b_0
-      - matplotlib=3.6.2=py39h6e9494a_0
+      - lz4-c=1.9.4=hf0c8a7f_0
+      - lz4=4.2.0=py39hd0af75a_0
+      - markupsafe=2.1.2=py39ha30fb19_0
+      - matplotlib-base=3.6.3=py39hb2f573b_0
+      - matplotlib=3.6.3=py39h6e9494a_0
       - msgpack-python=1.0.4=py39h92daf61_1
       - ncurses=6.3=h96cf925_1
       - netcdf4=1.6.2=nompi_py39h0d363ce_100
       - numba=0.56.4=py39hf6b9d82_0
       - numpy=1.23.5=py39hdfa1d0c_0
       - openjpeg=2.5.0=h13ac156_2
-      - openssl=3.0.7=hfd90126_1
-      - pandas=1.5.2=py39hecff1ad_0
+      - openssl=3.0.7=hfd90126_2
+      - pandas=1.5.3=py39hecff1ad_0
       - pandoc=2.19.2=h694c41f_1
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39h7f5cd59_4
+      - pillow=9.4.0=py39h193cfb4_0
       - psutil=5.9.4=py39ha30fb19_0
       - pthread-stubs=0.4=hc929b4f_1001
-      - pyrsistent=0.19.2=py39ha30fb19_0
+      - pyrsistent=0.19.3=py39ha30fb19_0
       - pysocks=1.7.1=py39h6e9494a_5
       - python=3.9.15=h709bd14_0_cpython
       - pyyaml=6.0=py39ha30fb19_5
-      - pyzmq=24.0.1=py39hed8f129_1
+      - pyzmq=25.0.0=py39hed8f129_0
       - readline=8.1.2=h3899abd_0
-      - scipy=1.9.3=py39h8a15683_2
-      - sqlalchemy=1.4.45=py39ha30fb19_0
+      - scipy=1.10.0=py39h8a15683_0
+      - sqlalchemy=1.4.46=py39ha30fb19_0
       - tk=8.6.12=h5dbffcc_0
       - tornado=6.2=py39ha30fb19_1
       - unicodedata2=15.0.0=py39ha30fb19_0
@@ -975,7 +948,7 @@ env_specs:
       - yaml=0.2.5=h0d85af4_2
       - zeromq=4.3.4=he49afe7_1
       - zlib=1.2.13=hfd90126_4
-      - zstd=1.5.2=hfa58983_4
+      - zstd=1.5.2=hbc0c0cd_6
       osx-arm64:
       - argon2-cffi-bindings=21.2.0=py39h02fc5c5_3
       - bokeh=2.4.3=py39h2804cbe_0
@@ -988,26 +961,27 @@ env_specs:
       - cffi=1.15.1=py39h7e6b969_3
       - cftime=1.6.2=py39h4d8bf0d_1
       - click=8.1.3=py39h2804cbe_1
-      - contourpy=1.0.6=py39haaf3ac1_0
+      - contourpy=1.0.7=py39haaf3ac1_0
       - cramjam=2.6.2=py39hb39fadb_0
-      - cryptography=38.0.4=py39he2a39a8_0
+      - cryptography=39.0.0=py39he2a39a8_0
       - curl=7.87.0=h9049daf_0
       - cytoolz=0.12.0=py39h02fc5c5_1
-      - debugpy=1.6.4=py39h23fbdae_0
+      - debugpy=1.6.6=py39h23fbdae_0
       - docutils=0.16=py39h2804cbe_3
-      - fastparquet=2022.12.0=py39h4d8bf0d_0
+      - fastparquet=2023.1.0=py39h4d8bf0d_0
       - fonttools=4.38.0=py39h02fc5c5_1
       - freetype=2.12.1=hd633e50_1
-      - greenlet=2.0.1=py39h23fbdae_0
+      - greenlet=2.0.2=py39h23fbdae_0
       - hdf4=4.2.15=h1a38d6a_5
-      - hdf5=1.12.2=nompi_h33dac16_100
+      - hdf5=1.12.2=nompi_ha7af310_101
       - icu=70.1=h6b3803e_0
       - jpeg=9e=he4db4b2_2
-      - jupyter_core=5.1.0=py39h2804cbe_0
+      - jupyter_core=5.1.5=py39h2804cbe_0
       - kiwisolver=1.4.4=py39haaf3ac1_1
       - krb5=1.20.1=h69eda48_0
       - lcms2=2.14=h481adae_1
       - lerc=4.0.0=h9a09cb3_0
+      - libaec=1.0.6=hb7217d7_1
       - libblas=3.9.0=16_osxarm64_openblas
       - libbrotlicommon=1.0.9=h1a8c8d9_8
       - libbrotlidec=1.0.9=h1a8c8d9_8
@@ -1015,56 +989,57 @@ env_specs:
       - libcblas=3.9.0=16_osxarm64_openblas
       - libcurl=7.87.0=h9049daf_0
       - libcxx=14.0.6=h2692d47_0
-      - libdeflate=1.14=h1a8c8d9_0
+      - libdeflate=1.17=h1a8c8d9_0
       - libedit=3.1.20191231=hc8eb9b7_2
       - libev=4.33=h642e427_1
       - libffi=3.4.2=h3422bc3_5
       - libgfortran5=11.3.0=hdaf2cc0_27
       - libgfortran=5.0.0=11_3_0_hd922786_27
       - libiconv=1.17=he4db4b2_0
+      - libjpeg-turbo=2.1.4=h1a8c8d9_0
       - liblapack=3.9.0=16_osxarm64_openblas
       - libllvm11=11.1.0=hfa12f05_5
       - libnetcdf=4.8.1=nompi_h2510be2_106
-      - libnghttp2=1.47.0=h519802c_1
+      - libnghttp2=1.51.0=hae82a92_0
       - libopenblas=0.3.21=openmp_hc731615_3
       - libpng=1.6.39=h76d750c_0
       - libsodium=1.0.18=h27ca646_1
       - libsqlite=3.40.0=h76d750c_0
       - libssh2=1.10.0=h7a5bd25_3
-      - libtiff=4.5.0=heb92581_0
+      - libtiff=4.5.0=h5dffbdd_2
       - libwebp-base=1.2.4=h57fd34a_0
       - libxcb=1.13=h9b22ae9_1004
       - libxml2=2.10.3=h87b0503_0
       - libzip=1.9.2=h76ab92c_1
       - libzlib=1.2.13=h03a7124_4
-      - llvm-openmp=15.0.6=h7cfbb63_0
+      - llvm-openmp=15.0.7=h7cfbb63_0
       - llvmlite=0.39.1=py39h8ca5d33_1
-      - lz4-c=1.9.3=hbdafb3b_1
-      - lz4=4.0.2=py39hb35ce34_0
-      - markupsafe=2.1.1=py39h02fc5c5_2
-      - matplotlib-base=3.6.2=py39h35e9e80_0
-      - matplotlib=3.6.2=py39hdf13c20_0
+      - lz4-c=1.9.4=hb7217d7_0
+      - lz4=4.2.0=py39hb35ce34_0
+      - markupsafe=2.1.2=py39h02fc5c5_0
+      - matplotlib-base=3.6.3=py39h35e9e80_0
+      - matplotlib=3.6.3=py39hdf13c20_0
       - msgpack-python=1.0.4=py39haaf3ac1_1
       - ncurses=6.3=h07bb92c_1
       - netcdf4=1.6.2=nompi_py39h8ded8ba_100
       - numba=0.56.4=py39h251cc7c_0
       - numpy=1.23.5=py39hefdcf20_0
       - openjpeg=2.5.0=hbc2ba62_2
-      - openssl=3.0.7=h03a7124_1
-      - pandas=1.5.2=py39hde7b980_0
+      - openssl=3.0.7=h03a7124_2
+      - pandas=1.5.3=py39hde7b980_0
       - pandoc=2.19.2=hce30654_1
       - pickleshare=0.7.5=py_1003
-      - pillow=9.2.0=py39h8bd98a6_4
+      - pillow=9.4.0=py39h8bbe137_0
       - psutil=5.9.4=py39h02fc5c5_0
       - pthread-stubs=0.4=h27ca646_1001
-      - pyrsistent=0.19.2=py39h02fc5c5_0
+      - pyrsistent=0.19.3=py39h02fc5c5_0
       - pysocks=1.7.1=py39h2804cbe_5
       - python=3.9.15=hea58f1e_0_cpython
       - pyyaml=6.0=py39h02fc5c5_5
-      - pyzmq=24.0.1=py39h0553236_1
+      - pyzmq=25.0.0=py39h0553236_0
       - readline=8.1.2=h46ed386_0
-      - scipy=1.9.3=py39h18313fe_2
-      - sqlalchemy=1.4.45=py39h02fc5c5_0
+      - scipy=1.10.0=py39h18313fe_0
+      - sqlalchemy=1.4.46=py39h02fc5c5_0
       - tk=8.6.12=he1e0b03_0
       - tornado=6.2=py39h02fc5c5_1
       - unicodedata2=15.0.0=py39h02fc5c5_0
@@ -1074,7 +1049,7 @@ env_specs:
       - yaml=0.2.5=h3422bc3_2
       - zeromq=4.3.4=hbdafb3b_1
       - zlib=1.2.13=h03a7124_4
-      - zstd=1.5.2=h8128057_4
+      - zstd=1.5.2=hf913c23_6
       win-64:
       - argon2-cffi-bindings=21.2.0=py39ha55989b_3
       - bokeh=2.4.3=py39hcbf5309_0
@@ -1086,47 +1061,49 @@ env_specs:
       - cffi=1.15.1=py39h68f70e3_3
       - cftime=1.6.2=py39hc266a54_1
       - click=8.1.3=py39hcbf5309_1
-      - contourpy=1.0.6=py39h1f6ef14_0
+      - contourpy=1.0.7=py39h1f6ef14_0
       - cramjam=2.6.2=py39h424382f_0
-      - cryptography=38.0.4=py39hb6bd5e6_0
+      - cryptography=39.0.0=py39hb6bd5e6_0
       - curl=7.87.0=h68f0423_0
       - cytoolz=0.12.0=py39ha55989b_1
-      - debugpy=1.6.4=py39h99910a6_0
+      - debugpy=1.6.6=py39h99910a6_0
       - docutils=0.16=py39hcbf5309_3
-      - fastparquet=2022.12.0=py39hc266a54_0
+      - fastparquet=2023.1.0=py39hc266a54_0
       - fonttools=4.38.0=py39ha55989b_1
       - freetype=2.12.1=h546665d_1
       - gettext=0.21.1=h5728263_0
       - glib-tools=2.74.1=h12be248_1
       - glib=2.74.1=h12be248_1
-      - greenlet=2.0.1=py39h99910a6_0
+      - greenlet=2.0.2=py39h99910a6_0
       - gst-plugins-base=1.21.3=h001b923_1
       - gstreamer=1.21.3=h6b5321d_1
       - hdf4=4.2.15=h1b1b6ef_5
-      - hdf5=1.12.2=nompi_h57737ce_100
+      - hdf5=1.12.2=nompi_h57737ce_101
       - icu=70.1=h0e60522_0
       - intel-openmp=2023.0.0=h57928b3_25922
-      - ipykernel=6.19.4=pyh025b116_0
-      - ipython=8.7.0=pyh08f2357_0
+      - ipykernel=6.20.2=pyh025b116_0
+      - ipython=8.9.0=pyh08f2357_0
       - jpeg=9e=h8ffe710_2
-      - jupyter_core=5.1.0=py39hcbf5309_0
+      - jupyter_core=5.1.5=py39hcbf5309_0
       - kiwisolver=1.4.4=py39h1f6ef14_1
       - krb5=1.20.1=heb0366b_0
       - lcms2=2.14=ha5c8aab_1
       - lerc=4.0.0=h63175ca_0
+      - libaec=1.0.6=h63175ca_1
       - libblas=3.9.0=16_win64_mkl
       - libbrotlicommon=1.0.9=hcfcfb64_8
       - libbrotlidec=1.0.9=hcfcfb64_8
       - libbrotlienc=1.0.9=hcfcfb64_8
       - libcblas=3.9.0=16_win64_mkl
-      - libclang13=15.0.6=default_h77d9078_0
-      - libclang=15.0.6=default_h77d9078_0
+      - libclang13=15.0.7=default_h77d9078_0
+      - libclang=15.0.7=default_h77d9078_0
       - libcurl=7.87.0=h68f0423_0
-      - libdeflate=1.14=hcfcfb64_0
+      - libdeflate=1.17=hcfcfb64_0
       - libffi=3.4.2=h8ffe710_5
       - libglib=2.74.1=he8f3873_1
       - libhwloc=2.8.0=h039e092_1
       - libiconv=1.17=h8ffe710_0
+      - libjpeg-turbo=2.1.4=hcfcfb64_0
       - liblapack=3.9.0=16_win64_mkl
       - libnetcdf=4.8.1=nompi_h8c042bf_106
       - libogg=1.3.4=h8ffe710_1
@@ -1134,7 +1111,7 @@ env_specs:
       - libsodium=1.0.18=h8d14728_1
       - libsqlite=3.40.0=hcfcfb64_0
       - libssh2=1.10.0=h9a1e1f7_3
-      - libtiff=4.5.0=hc4f729c_0
+      - libtiff=4.5.0=hf8721a0_2
       - libvorbis=1.3.7=h0e60522_0
       - libwebp-base=1.2.4=h8ffe710_0
       - libxcb=1.13=hcd874cb_1004
@@ -1142,16 +1119,16 @@ env_specs:
       - libzip=1.9.2=h519de47_1
       - libzlib=1.2.13=hcfcfb64_4
       - llvmlite=0.39.1=py39hd28a505_1
-      - lz4-c=1.9.3=h8ffe710_1
-      - lz4=4.0.2=py39hf617134_0
+      - lz4-c=1.9.4=hcfcfb64_0
+      - lz4=4.2.0=py39hf617134_0
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
       - m2w64-gmp=6.1.0=2
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
-      - markupsafe=2.1.1=py39ha55989b_2
-      - matplotlib-base=3.6.2=py39haf65ace_0
-      - matplotlib=3.6.2=py39hcbf5309_0
+      - markupsafe=2.1.2=py39ha55989b_0
+      - matplotlib-base=3.6.3=py39haf65ace_0
+      - matplotlib=3.6.3=py39hcbf5309_0
       - mkl=2022.1.0=h6a75c08_874
       - msgpack-python=1.0.4=py39h1f6ef14_1
       - msys2-conda-epoch=20160418=1
@@ -1160,29 +1137,29 @@ env_specs:
       - numba=0.56.4=py39h99ae161_0
       - numpy=1.23.5=py39hbccbffa_0
       - openjpeg=2.5.0=ha2aaf27_2
-      - openssl=3.0.7=hcfcfb64_1
-      - pandas=1.5.2=py39h2ba5b7c_0
+      - openssl=3.0.7=hcfcfb64_2
+      - pandas=1.5.3=py39h2ba5b7c_0
       - pandoc=2.19.2=h57928b3_1
       - pcre2=10.40=h17e33f8_0
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39hcebd2be_4
+      - pillow=9.4.0=py39h9767c21_0
       - ply=3.11=py_1
       - psutil=5.9.4=py39ha55989b_0
       - pthread-stubs=0.4=hcd874cb_1001
       - pthreads-win32=2.9.1=hfa6e2cd_3
-      - pyqt5-sip=12.11.0=py39h99910a6_2
-      - pyqt=5.15.7=py39hb77abff_2
-      - pyrsistent=0.19.2=py39ha55989b_0
+      - pyqt5-sip=12.11.0=py39h99910a6_3
+      - pyqt=5.15.7=py39hb77abff_3
+      - pyrsistent=0.19.3=py39ha55989b_0
       - pysocks=1.7.1=py39hcbf5309_5
       - python=3.9.15=h4de0772_0_cpython
       - pywin32=304=py39h99910a6_2
-      - pywinpty=2.0.9=py39h99910a6_0
+      - pywinpty=2.0.10=py39h99910a6_0
       - pyyaml=6.0=py39ha55989b_5
-      - pyzmq=24.0.1=py39hea35a22_1
-      - qt-main=5.15.6=h9580fe5_5
-      - scipy=1.9.3=py39hfbf2dce_2
-      - sip=6.7.5=py39h99910a6_0
-      - sqlalchemy=1.4.45=py39ha55989b_0
+      - pyzmq=25.0.0=py39hea35a22_0
+      - qt-main=5.15.6=h9580fe5_6
+      - scipy=1.10.0=py39hfbf2dce_0
+      - sip=6.7.6=py39h99910a6_0
+      - sqlalchemy=1.4.46=py39ha55989b_0
       - tbb=2021.7.0=h91493d7_1
       - terminado=0.17.0=pyh08f2357_0
       - tk=8.6.12=h8ffe710_0
@@ -1190,8 +1167,8 @@ env_specs:
       - tornado=6.2=py39ha55989b_1
       - ucrt=10.0.22621.0=h57928b3_0
       - unicodedata2=15.0.0=py39ha55989b_0
-      - vc=14.3=h3d8a991_9
-      - vs2015_runtime=14.32.31332=h1d6e394_9
+      - vc=14.3=hb6edc58_10
+      - vs2015_runtime=14.34.31931=h4c5c07a_10
       - win_inet_pton=1.1.0=py39hcbf5309_5
       - winpty=0.4.3=4
       - xorg-libxau=1.0.9=hcd874cb_0
@@ -1200,7 +1177,7 @@ env_specs:
       - yaml=0.2.5=h8ffe710_2
       - zeromq=4.3.4=h0e60522_1
       - zlib=1.2.13=hcfcfb64_4
-      - zstd=1.5.2=h7755175_4
+      - zstd=1.5.2=h12be248_6
   default:
     locked: true
     env_spec_hash: 90e4958da1cad028257a8c765d27126b02679298
@@ -1211,58 +1188,58 @@ env_specs:
     - win-64
     packages:
       all:
-      - _ipython_minor_entry_point=8.7.0=h8cf3c4a_0
       - anyio=3.6.2=pyhd8ed1ab_0
+      - appdirs=1.4.4=pyh9f0ad1d_0
       - argon2-cffi=21.3.0=pyhd8ed1ab_0
       - asttokens=2.2.1=pyhd8ed1ab_0
-      - attrs=22.1.0=pyh71513ae_1
+      - attrs=22.2.0=pyh71513ae_0
       - babel=2.11.0=pyhd8ed1ab_0
       - backcall=0.2.0=pyh9f0ad1d_0
       - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
       - backports=1.0=pyhd8ed1ab_3
       - beautifulsoup4=4.11.1=pyha770c72_0
-      - bleach=5.0.1=pyhd8ed1ab_0
+      - bleach=6.0.0=pyhd8ed1ab_0
       - certifi=2022.12.7=pyhd8ed1ab_0
       - charset-normalizer=2.1.1=pyhd8ed1ab_0
-      - cloudpickle=2.2.0=pyhd8ed1ab_0
+      - cloudpickle=2.2.1=pyhd8ed1ab_0
       - colorama=0.4.6=pyhd8ed1ab_0
       - colorcet=3.0.1=py_0
       - comm=0.1.2=pyhd8ed1ab_0
       - cycler=0.11.0=pyhd8ed1ab_0
-      - dask-core=2022.12.1=pyhd8ed1ab_0
-      - dask=2022.12.1=pyhd8ed1ab_0
+      - dask-core=2023.1.1=pyhd8ed1ab_0
+      - dask=2023.1.1=pyhd8ed1ab_0
       - datashader=0.14.1=py_0
       - datashape=0.5.4=py_1
       - decorator=5.1.1=pyhd8ed1ab_0
       - defusedxml=0.7.1=pyhd8ed1ab_0
-      - distributed=2022.12.1=pyhd8ed1ab_0
+      - distributed=2023.1.1=pyhd8ed1ab_0
       - entrypoints=0.4=pyhd8ed1ab_0
       - executing=1.2.0=pyhd8ed1ab_0
       - flit-core=3.8.0=pyhd8ed1ab_0
-      - fsspec=2022.11.0=pyhd8ed1ab_0
+      - fsspec=2023.1.0=pyhd8ed1ab_0
       - heapdict=1.0.1=py_0
       - holoviews=1.15.0=py_0
       - hvplot=0.8.0=py_0
       - idna=3.4=pyhd8ed1ab_0
-      - importlib-metadata=5.2.0=pyha770c72_0
-      - importlib_resources=5.10.1=pyhd8ed1ab_0
+      - importlib-metadata=6.0.0=pyha770c72_0
+      - importlib_resources=5.10.2=pyhd8ed1ab_0
       - ipympl=0.9.2=pyhd8ed1ab_0
       - ipython_genutils=0.2.0=py_1
-      - ipywidgets=7.7.2=pyhd8ed1ab_0
+      - ipywidgets=8.0.4=pyhd8ed1ab_0
       - jedi=0.18.2=pyhd8ed1ab_0
       - jinja2=3.1.2=pyhd8ed1ab_1
       - json5=0.9.5=pyh9f0ad1d_0
       - jsonschema=4.17.3=pyhd8ed1ab_0
-      - jupyter_client=7.4.8=pyhd8ed1ab_0
+      - jupyter_client=7.4.9=pyhd8ed1ab_0
       - jupyter_contrib_core=0.4.0=pyhd8ed1ab_0
-      - jupyter_events=0.5.0=pyhd8ed1ab_0
+      - jupyter_events=0.6.3=pyhd8ed1ab_0
       - jupyter_nbextensions_configurator=0.6.1=pyhd8ed1ab_0
-      - jupyter_server=2.0.2=pyhd8ed1ab_0
-      - jupyter_server_terminals=0.4.3=pyhd8ed1ab_0
-      - jupyterlab=3.5.2=pyhd8ed1ab_0
+      - jupyter_server=2.1.0=pyhd8ed1ab_0
+      - jupyter_server_terminals=0.4.4=pyhd8ed1ab_1
+      - jupyterlab=3.5.3=pyhd8ed1ab_0
       - jupyterlab_pygments=0.2.2=pyhd8ed1ab_0
-      - jupyterlab_server=2.16.5=pyhd8ed1ab_0
-      - jupyterlab_widgets=1.1.1=pyhd8ed1ab_0
+      - jupyterlab_server=2.19.0=pyhd8ed1ab_0
+      - jupyterlab_widgets=3.0.5=pyhd8ed1ab_0
       - locket=1.0.0=pyhd8ed1ab_0
       - markdown=3.4.1=pyhd8ed1ab_0
       - matplotlib-inline=0.1.6=pyhd8ed1ab_0
@@ -1270,14 +1247,14 @@ env_specs:
       - multipledispatch=0.6.0=py_0
       - nbclassic=0.4.8=pyhd8ed1ab_0
       - nbclient=0.7.2=pyhd8ed1ab_0
-      - nbconvert-core=7.2.7=pyhd8ed1ab_0
-      - nbconvert-pandoc=7.2.7=pyhd8ed1ab_0
-      - nbconvert=7.2.7=pyhd8ed1ab_0
-      - nbformat=5.7.1=pyhd8ed1ab_0
+      - nbconvert-core=7.2.9=pyhd8ed1ab_0
+      - nbconvert-pandoc=7.2.9=pyhd8ed1ab_0
+      - nbconvert=7.2.9=pyhd8ed1ab_0
+      - nbformat=5.7.3=pyhd8ed1ab_0
       - nest-asyncio=1.5.6=pyhd8ed1ab_0
       - notebook-shim=0.2.2=pyhd8ed1ab_0
       - notebook=6.5.2=pyha770c72_1
-      - packaging=22.0=pyhd8ed1ab_0
+      - packaging=23.0=pyhd8ed1ab_0
       - pandocfilters=1.5.0=pyhd8ed1ab_0
       - panel=0.13.1=py_0
       - param=1.12.2=py_0
@@ -1285,26 +1262,29 @@ env_specs:
       - partd=1.3.0=pyhd8ed1ab_0
       - pip=22.3.1=pyhd8ed1ab_0
       - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_0
-      - platformdirs=2.6.0=pyhd8ed1ab_0
-      - plotly=5.11.0=pyhd8ed1ab_1
-      - prometheus_client=0.15.0=pyhd8ed1ab_0
+      - platformdirs=2.6.2=pyhd8ed1ab_0
+      - plotly=5.13.0=pyhd8ed1ab_0
+      - pooch=1.6.0=pyhd8ed1ab_0
+      - prometheus_client=0.16.0=pyhd8ed1ab_0
       - prompt-toolkit=3.0.36=pyha770c72_0
       - pure_eval=0.2.2=pyhd8ed1ab_0
       - pycparser=2.21=pyhd8ed1ab_0
       - pyct-core=0.4.8=py_0
       - pyct=0.4.8=py_0
-      - pygments=2.13.0=pyhd8ed1ab_0
-      - pyopenssl=22.1.0=pyhd8ed1ab_0
+      - pygments=2.14.0=pyhd8ed1ab_0
+      - pyopenssl=23.0.0=pyhd8ed1ab_0
       - pyparsing=3.0.9=pyhd8ed1ab_0
       - python-dateutil=2.8.2=pyhd8ed1ab_0
       - python-fastjsonschema=2.16.2=pyhd8ed1ab_0
-      - python-json-logger=2.0.1=pyh9f0ad1d_0
+      - python-json-logger=2.0.4=pyhd8ed1ab_0
       - python_abi=3.9=3_cp39
-      - pytz=2022.7=pyhd8ed1ab_0
+      - pytz=2022.7.1=pyhd8ed1ab_0
       - pyviz_comms=2.2.1=py_0
-      - requests=2.28.1=pyhd8ed1ab_1
+      - requests=2.28.2=pyhd8ed1ab_0
+      - rfc3339-validator=0.1.4=pyhd8ed1ab_0
+      - rfc3986-validator=0.1.1=pyh9f0ad1d_0
       - send2trash=1.8.0=pyhd8ed1ab_0
-      - setuptools=65.6.3=pyhd8ed1ab_0
+      - setuptools=66.1.1=pyhd8ed1ab_0
       - six=1.16.0=pyh6c4a22f_0
       - sniffio=1.3.0=pyhd8ed1ab_0
       - sortedcontainers=2.4.0=pyhd8ed1ab_0
@@ -1316,25 +1296,26 @@ env_specs:
       - tomli=2.0.1=pyhd8ed1ab_0
       - toolz=0.12.0=pyhd8ed1ab_0
       - tqdm=4.64.1=pyhd8ed1ab_0
-      - traitlets=5.8.0=pyhd8ed1ab_0
+      - traitlets=5.8.1=pyhd8ed1ab_0
+      - typing-extensions=4.4.0=hd8ed1ab_0
       - typing_extensions=4.4.0=pyha770c72_0
       - tzdata=2022g=h191b570_0
-      - urllib3=1.26.13=pyhd8ed1ab_0
-      - wcwidth=0.2.5=pyh9f0ad1d_2
+      - urllib3=1.26.14=pyhd8ed1ab_0
+      - wcwidth=0.2.6=pyhd8ed1ab_0
       - webencodings=0.5.1=py_1
-      - websocket-client=1.4.2=pyhd8ed1ab_0
+      - websocket-client=1.5.0=pyhd8ed1ab_0
       - wheel=0.38.4=pyhd8ed1ab_0
-      - widgetsnbextension=3.6.1=pyha770c72_0
-      - xarray=2022.12.0=pyhd8ed1ab_0
+      - widgetsnbextension=4.0.5=pyhd8ed1ab_0
+      - xarray=2023.1.0=pyhd8ed1ab_0
       - zict=2.2.0=pyhd8ed1ab_0
-      - zipp=3.11.0=pyhd8ed1ab_0
+      - zipp=3.12.0=pyhd8ed1ab_0
       unix:
       - pexpect=4.8.0=pyh1a96a4e_2
       - ptyprocess=0.7.0=pyhd3deb0d_0
       osx:
       - appnope=0.1.3=pyhd8ed1ab_0
-      - ipykernel=6.19.4=pyh736e0ef_0
-      - ipython=8.7.0=pyhd1c38e8_0
+      - ipykernel=6.20.2=pyh736e0ef_0
+      - ipython=8.9.0=pyhd1c38e8_0
       - munkres=1.1.4=pyh9f0ad1d_0
       - terminado=0.17.1=pyhd1c38e8_0
       linux-64:
@@ -1350,29 +1331,30 @@ env_specs:
       - cftime=1.6.2=py39h2ae25f5_1
       - click=8.1.3=py39hf3d152e_1
       - cramjam=2.6.2=py39h4ef89ea_0
-      - cryptography=38.0.4=py39h3ccb8fc_0
+      - cryptography=39.0.0=py39h079d5ae_0
       - curl=7.87.0=hdc1c0ab_0
       - cytoolz=0.12.0=py39hb9d737c_1
-      - debugpy=1.6.4=py39h5a03fae_0
-      - fastparquet=2022.12.0=py39h389d5f1_0
+      - debugpy=1.6.6=py39h227be39_0
+      - fastparquet=2023.1.0=py39h389d5f1_0
       - freetype=2.12.1=hca18f0e_1
       - hdf4=4.2.15=h9772cbc_5
-      - hdf5=1.12.2=nompi_h4df4325_100
+      - hdf5=1.12.2=nompi_h4df4325_101
       - icu=70.1=h27087fc_0
-      - ipykernel=6.19.4=pyh210e3f2_0
-      - ipython=8.7.0=pyh41d4057_0
+      - ipykernel=6.20.2=pyh210e3f2_0
+      - ipython=8.9.0=pyh41d4057_0
       - jpeg=9e=h166bdaf_2
-      - jupyter_core=5.1.0=py39hf3d152e_0
+      - jupyter_core=5.1.5=py39hf3d152e_0
       - keyutils=1.6.1=h166bdaf_0
       - kiwisolver=1.4.4=py39hf939315_1
       - krb5=1.20.1=h81ceb04_0
       - lcms2=2.14=hfd0df8a_1
-      - ld_impl_linux-64=2.39=hcc3a1bd_1
+      - ld_impl_linux-64=2.40=h41732ed_0
       - lerc=4.0.0=h27087fc_0
+      - libaec=1.0.6=hcb278e6_1
       - libblas=3.9.0=16_linux64_openblas
       - libcblas=3.9.0=16_linux64_openblas
       - libcurl=7.87.0=hdc1c0ab_0
-      - libdeflate=1.14=h166bdaf_0
+      - libdeflate=1.17=h0b41bf4_0
       - libedit=3.1.20191231=he28a2e2_2
       - libev=4.33=h516909a_1
       - libffi=3.4.2=h7f98852_5
@@ -1381,10 +1363,11 @@ env_specs:
       - libgfortran5=12.2.0=h337968e_19
       - libgomp=12.2.0=h65d4601_19
       - libiconv=1.17=h166bdaf_0
+      - libjpeg-turbo=2.1.4=h166bdaf_0
       - liblapack=3.9.0=16_linux64_openblas
       - libllvm11=11.1.0=he0ac6c6_5
       - libnetcdf=4.8.1=nompi_h261ec11_106
-      - libnghttp2=1.47.0=hff17c54_1
+      - libnghttp2=1.51.0=hff17c54_0
       - libnsl=2.0.0=h7f98852_0
       - libopenblas=0.3.21=pthreads_h78a6416_3
       - libpng=1.6.39=h753d276_0
@@ -1392,7 +1375,7 @@ env_specs:
       - libsqlite=3.40.0=h753d276_0
       - libssh2=1.10.0=hf14f497_3
       - libstdcxx-ng=12.2.0=h46fd767_19
-      - libtiff=4.5.0=h82bc61c_0
+      - libtiff=4.5.0=h6adf6a1_2
       - libuuid=2.32.1=h7f98852_1000
       - libwebp-base=1.2.4=h166bdaf_0
       - libxcb=1.13=h7f98852_1004
@@ -1400,9 +1383,9 @@ env_specs:
       - libzip=1.9.2=hc929e4a_1
       - libzlib=1.2.13=h166bdaf_4
       - llvmlite=0.39.1=py39h7d9a04d_1
-      - lz4-c=1.9.3=h9c3ff4c_1
-      - lz4=4.0.2=py39h029007f_0
-      - markupsafe=2.1.1=py39hb9d737c_2
+      - lz4-c=1.9.4=hcb278e6_0
+      - lz4=4.2.0=py39h724f13c_0
+      - markupsafe=2.1.2=py39h72bdee0_0
       - matplotlib-base=3.3.2=py39h98787fa_1
       - matplotlib=3.3.2=0
       - msgpack-python=1.0.4=py39hf939315_1
@@ -1411,20 +1394,20 @@ env_specs:
       - numba=0.56.4=py39h61ddf18_0
       - numpy=1.23.5=py39h3d75532_0
       - openjpeg=2.5.0=hfec8fc6_2
-      - openssl=3.0.7=h0b41bf4_1
-      - pandas=1.5.2=py39h4661b88_0
+      - openssl=3.0.7=h0b41bf4_2
+      - pandas=1.5.3=py39h2ad29b5_0
       - pandoc=2.19.2=h32600fe_1
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39h2320bf1_4
+      - pillow=9.4.0=py39ha08a7e4_0
       - psutil=5.9.4=py39hb9d737c_0
       - pthread-stubs=0.4=h36c2ea0_1001
-      - pyrsistent=0.19.2=py39hb9d737c_0
+      - pyrsistent=0.19.3=py39h72bdee0_0
       - pysocks=1.7.1=py39hf3d152e_5
       - python=3.9.15=hba424b6_0_cpython
       - pyyaml=6.0=py39hb9d737c_5
-      - pyzmq=24.0.1=py39headdf64_1
+      - pyzmq=25.0.0=py39h0be026e_0
       - readline=8.1.2=h0f457ee_0
-      - scipy=1.9.3=py39hddc5342_2
+      - scipy=1.10.0=py39h7360e5f_0
       - terminado=0.17.1=pyh41d4057_0
       - tk=8.6.12=h27826a3_0
       - tornado=6.2=py39hb9d737c_1
@@ -1434,7 +1417,7 @@ env_specs:
       - yaml=0.2.5=h7f98852_2
       - zeromq=4.3.4=h9c3ff4c_1
       - zlib=1.2.13=h166bdaf_4
-      - zstd=1.5.2=h6239696_4
+      - zstd=1.5.2=h3eb15da_6
       osx-64:
       - argon2-cffi-bindings=21.2.0=py39ha30fb19_3
       - bokeh=2.4.3=py39h6e9494a_0
@@ -1447,24 +1430,25 @@ env_specs:
       - cffi=1.15.1=py39h131948b_3
       - cftime=1.6.2=py39h7cc1f47_1
       - click=8.1.3=py39h6e9494a_1
-      - contourpy=1.0.6=py39h92daf61_0
+      - contourpy=1.0.7=py39h92daf61_0
       - cramjam=2.6.2=py39hd4bc93a_0
-      - cryptography=38.0.4=py39hbeae22c_0
+      - cryptography=39.0.0=py39hbeae22c_0
       - curl=7.87.0=h6df9250_0
       - cytoolz=0.12.0=py39ha30fb19_1
-      - debugpy=1.6.4=py39h7a8716b_0
-      - fastparquet=2022.12.0=py39h7cc1f47_0
+      - debugpy=1.6.6=py39h7a8716b_0
+      - fastparquet=2023.1.0=py39h7cc1f47_0
       - fonttools=4.38.0=py39ha30fb19_1
       - freetype=2.12.1=h3f81eb7_1
       - hdf4=4.2.15=h7aa5921_5
-      - hdf5=1.12.2=nompi_h1f71328_100
+      - hdf5=1.12.2=nompi_h48135f9_101
       - icu=70.1=h96cf925_0
       - jpeg=9e=hac89ed1_2
-      - jupyter_core=5.1.0=py39h6e9494a_0
+      - jupyter_core=5.1.5=py39h6e9494a_0
       - kiwisolver=1.4.4=py39h92daf61_1
       - krb5=1.20.1=h049b76e_0
       - lcms2=2.14=h29502cd_1
       - lerc=4.0.0=hb486fe8_0
+      - libaec=1.0.6=hf0c8a7f_1
       - libblas=3.9.0=16_osx64_openblas
       - libbrotlicommon=1.0.9=hb7f2c08_8
       - libbrotlidec=1.0.9=hb7f2c08_8
@@ -1472,55 +1456,56 @@ env_specs:
       - libcblas=3.9.0=16_osx64_openblas
       - libcurl=7.87.0=h6df9250_0
       - libcxx=14.0.6=hccf4f1f_0
-      - libdeflate=1.14=hb7f2c08_0
+      - libdeflate=1.17=hac1461d_0
       - libedit=3.1.20191231=h0678c8f_2
       - libev=4.33=haf1e3a3_1
       - libffi=3.4.2=h0d85af4_5
       - libgfortran5=11.3.0=h082f757_27
       - libgfortran=5.0.0=11_3_0_h97931a8_27
       - libiconv=1.17=hac89ed1_0
+      - libjpeg-turbo=2.1.4=hb7f2c08_0
       - liblapack=3.9.0=16_osx64_openblas
       - libllvm11=11.1.0=h8fb7429_5
       - libnetcdf=4.8.1=nompi_hc61b76e_106
-      - libnghttp2=1.47.0=h5aae05b_1
+      - libnghttp2=1.51.0=he2ab024_0
       - libopenblas=0.3.21=openmp_h429af6e_3
       - libpng=1.6.39=ha978bb4_0
       - libsodium=1.0.18=hbcb3906_1
       - libsqlite=3.40.0=ha978bb4_0
       - libssh2=1.10.0=h47af595_3
-      - libtiff=4.5.0=h6268bbc_0
+      - libtiff=4.5.0=hee9004a_2
       - libwebp-base=1.2.4=h775f41a_0
       - libxcb=1.13=h0d85af4_1004
       - libxml2=2.10.3=hb9e07b5_0
       - libzip=1.9.2=h6db710c_1
       - libzlib=1.2.13=hfd90126_4
-      - llvm-openmp=15.0.6=h61d9ccf_0
+      - llvm-openmp=15.0.7=h61d9ccf_0
       - llvmlite=0.39.1=py39had167e2_1
-      - lz4-c=1.9.3=he49afe7_1
-      - lz4=4.0.2=py39hd0af75a_0
-      - markupsafe=2.1.1=py39ha30fb19_2
-      - matplotlib-base=3.6.2=py39hb2f573b_0
-      - matplotlib=3.6.2=py39h6e9494a_0
+      - lz4-c=1.9.4=hf0c8a7f_0
+      - lz4=4.2.0=py39hd0af75a_0
+      - markupsafe=2.1.2=py39ha30fb19_0
+      - matplotlib-base=3.6.3=py39hb2f573b_0
+      - matplotlib=3.6.3=py39h6e9494a_0
       - msgpack-python=1.0.4=py39h92daf61_1
       - ncurses=6.3=h96cf925_1
       - netcdf4=1.6.2=nompi_py39h0d363ce_100
       - numba=0.56.4=py39hf6b9d82_0
       - numpy=1.23.5=py39hdfa1d0c_0
       - openjpeg=2.5.0=h13ac156_2
-      - openssl=3.0.7=hfd90126_1
-      - pandas=1.5.2=py39hecff1ad_0
+      - openssl=3.0.7=hfd90126_2
+      - pandas=1.5.3=py39hecff1ad_0
       - pandoc=2.19.2=h694c41f_1
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39h7f5cd59_4
+      - pillow=9.4.0=py39h193cfb4_0
       - psutil=5.9.4=py39ha30fb19_0
       - pthread-stubs=0.4=hc929b4f_1001
-      - pyrsistent=0.19.2=py39ha30fb19_0
+      - pyrsistent=0.19.3=py39ha30fb19_0
       - pysocks=1.7.1=py39h6e9494a_5
       - python=3.9.15=h709bd14_0_cpython
       - pyyaml=6.0=py39ha30fb19_5
-      - pyzmq=24.0.1=py39hed8f129_1
+      - pyzmq=25.0.0=py39hed8f129_0
       - readline=8.1.2=h3899abd_0
-      - scipy=1.9.3=py39h8a15683_2
+      - scipy=1.10.0=py39h8a15683_0
       - tk=8.6.12=h5dbffcc_0
       - tornado=6.2=py39ha30fb19_1
       - unicodedata2=15.0.0=py39ha30fb19_0
@@ -1530,7 +1515,7 @@ env_specs:
       - yaml=0.2.5=h0d85af4_2
       - zeromq=4.3.4=he49afe7_1
       - zlib=1.2.13=hfd90126_4
-      - zstd=1.5.2=hfa58983_4
+      - zstd=1.5.2=hbc0c0cd_6
       osx-arm64:
       - argon2-cffi-bindings=21.2.0=py39h02fc5c5_3
       - bokeh=2.4.3=py39h2804cbe_0
@@ -1543,24 +1528,25 @@ env_specs:
       - cffi=1.15.1=py39h7e6b969_3
       - cftime=1.6.2=py39h4d8bf0d_1
       - click=8.1.3=py39h2804cbe_1
-      - contourpy=1.0.6=py39haaf3ac1_0
+      - contourpy=1.0.7=py39haaf3ac1_0
       - cramjam=2.6.2=py39hb39fadb_0
-      - cryptography=38.0.4=py39he2a39a8_0
+      - cryptography=39.0.0=py39he2a39a8_0
       - curl=7.87.0=h9049daf_0
       - cytoolz=0.12.0=py39h02fc5c5_1
-      - debugpy=1.6.4=py39h23fbdae_0
-      - fastparquet=2022.12.0=py39h4d8bf0d_0
+      - debugpy=1.6.6=py39h23fbdae_0
+      - fastparquet=2023.1.0=py39h4d8bf0d_0
       - fonttools=4.38.0=py39h02fc5c5_1
       - freetype=2.12.1=hd633e50_1
       - hdf4=4.2.15=h1a38d6a_5
-      - hdf5=1.12.2=nompi_h33dac16_100
+      - hdf5=1.12.2=nompi_ha7af310_101
       - icu=70.1=h6b3803e_0
       - jpeg=9e=he4db4b2_2
-      - jupyter_core=5.1.0=py39h2804cbe_0
+      - jupyter_core=5.1.5=py39h2804cbe_0
       - kiwisolver=1.4.4=py39haaf3ac1_1
       - krb5=1.20.1=h69eda48_0
       - lcms2=2.14=h481adae_1
       - lerc=4.0.0=h9a09cb3_0
+      - libaec=1.0.6=hb7217d7_1
       - libblas=3.9.0=16_osxarm64_openblas
       - libbrotlicommon=1.0.9=h1a8c8d9_8
       - libbrotlidec=1.0.9=h1a8c8d9_8
@@ -1568,55 +1554,56 @@ env_specs:
       - libcblas=3.9.0=16_osxarm64_openblas
       - libcurl=7.87.0=h9049daf_0
       - libcxx=14.0.6=h2692d47_0
-      - libdeflate=1.14=h1a8c8d9_0
+      - libdeflate=1.17=h1a8c8d9_0
       - libedit=3.1.20191231=hc8eb9b7_2
       - libev=4.33=h642e427_1
       - libffi=3.4.2=h3422bc3_5
       - libgfortran5=11.3.0=hdaf2cc0_27
       - libgfortran=5.0.0=11_3_0_hd922786_27
       - libiconv=1.17=he4db4b2_0
+      - libjpeg-turbo=2.1.4=h1a8c8d9_0
       - liblapack=3.9.0=16_osxarm64_openblas
       - libllvm11=11.1.0=hfa12f05_5
       - libnetcdf=4.8.1=nompi_h2510be2_106
-      - libnghttp2=1.47.0=h519802c_1
+      - libnghttp2=1.51.0=hae82a92_0
       - libopenblas=0.3.21=openmp_hc731615_3
       - libpng=1.6.39=h76d750c_0
       - libsodium=1.0.18=h27ca646_1
       - libsqlite=3.40.0=h76d750c_0
       - libssh2=1.10.0=h7a5bd25_3
-      - libtiff=4.5.0=heb92581_0
+      - libtiff=4.5.0=h5dffbdd_2
       - libwebp-base=1.2.4=h57fd34a_0
       - libxcb=1.13=h9b22ae9_1004
       - libxml2=2.10.3=h87b0503_0
       - libzip=1.9.2=h76ab92c_1
       - libzlib=1.2.13=h03a7124_4
-      - llvm-openmp=15.0.6=h7cfbb63_0
+      - llvm-openmp=15.0.7=h7cfbb63_0
       - llvmlite=0.39.1=py39h8ca5d33_1
-      - lz4-c=1.9.3=hbdafb3b_1
-      - lz4=4.0.2=py39hb35ce34_0
-      - markupsafe=2.1.1=py39h02fc5c5_2
-      - matplotlib-base=3.6.2=py39h35e9e80_0
-      - matplotlib=3.6.2=py39hdf13c20_0
+      - lz4-c=1.9.4=hb7217d7_0
+      - lz4=4.2.0=py39hb35ce34_0
+      - markupsafe=2.1.2=py39h02fc5c5_0
+      - matplotlib-base=3.6.3=py39h35e9e80_0
+      - matplotlib=3.6.3=py39hdf13c20_0
       - msgpack-python=1.0.4=py39haaf3ac1_1
       - ncurses=6.3=h07bb92c_1
       - netcdf4=1.6.2=nompi_py39h8ded8ba_100
       - numba=0.56.4=py39h251cc7c_0
       - numpy=1.23.5=py39hefdcf20_0
       - openjpeg=2.5.0=hbc2ba62_2
-      - openssl=3.0.7=h03a7124_1
-      - pandas=1.5.2=py39hde7b980_0
+      - openssl=3.0.7=h03a7124_2
+      - pandas=1.5.3=py39hde7b980_0
       - pandoc=2.19.2=hce30654_1
       - pickleshare=0.7.5=py_1003
-      - pillow=9.2.0=py39h8bd98a6_4
+      - pillow=9.4.0=py39h8bbe137_0
       - psutil=5.9.4=py39h02fc5c5_0
       - pthread-stubs=0.4=h27ca646_1001
-      - pyrsistent=0.19.2=py39h02fc5c5_0
+      - pyrsistent=0.19.3=py39h02fc5c5_0
       - pysocks=1.7.1=py39h2804cbe_5
       - python=3.9.15=hea58f1e_0_cpython
       - pyyaml=6.0=py39h02fc5c5_5
-      - pyzmq=24.0.1=py39h0553236_1
+      - pyzmq=25.0.0=py39h0553236_0
       - readline=8.1.2=h46ed386_0
-      - scipy=1.9.3=py39h18313fe_2
+      - scipy=1.10.0=py39h18313fe_0
       - tk=8.6.12=he1e0b03_0
       - tornado=6.2=py39h02fc5c5_1
       - unicodedata2=15.0.0=py39h02fc5c5_0
@@ -1626,7 +1613,7 @@ env_specs:
       - yaml=0.2.5=h3422bc3_2
       - zeromq=4.3.4=hbdafb3b_1
       - zlib=1.2.13=h03a7124_4
-      - zstd=1.5.2=h8128057_4
+      - zstd=1.5.2=hf913c23_6
       win-64:
       - argon2-cffi-bindings=21.2.0=py39ha55989b_3
       - bokeh=2.4.3=py39hcbf5309_0
@@ -1638,13 +1625,13 @@ env_specs:
       - cffi=1.15.1=py39h68f70e3_3
       - cftime=1.6.2=py39hc266a54_1
       - click=8.1.3=py39hcbf5309_1
-      - contourpy=1.0.6=py39h1f6ef14_0
+      - contourpy=1.0.7=py39h1f6ef14_0
       - cramjam=2.6.2=py39h424382f_0
-      - cryptography=38.0.4=py39hb6bd5e6_0
+      - cryptography=39.0.0=py39hb6bd5e6_0
       - curl=7.87.0=h68f0423_0
       - cytoolz=0.12.0=py39ha55989b_1
-      - debugpy=1.6.4=py39h99910a6_0
-      - fastparquet=2022.12.0=py39hc266a54_0
+      - debugpy=1.6.6=py39h99910a6_0
+      - fastparquet=2023.1.0=py39hc266a54_0
       - fonttools=4.38.0=py39ha55989b_1
       - freetype=2.12.1=h546665d_1
       - gettext=0.21.1=h5728263_0
@@ -1653,30 +1640,32 @@ env_specs:
       - gst-plugins-base=1.21.3=h001b923_1
       - gstreamer=1.21.3=h6b5321d_1
       - hdf4=4.2.15=h1b1b6ef_5
-      - hdf5=1.12.2=nompi_h57737ce_100
+      - hdf5=1.12.2=nompi_h57737ce_101
       - icu=70.1=h0e60522_0
       - intel-openmp=2023.0.0=h57928b3_25922
-      - ipykernel=6.19.4=pyh025b116_0
-      - ipython=8.7.0=pyh08f2357_0
+      - ipykernel=6.20.2=pyh025b116_0
+      - ipython=8.9.0=pyh08f2357_0
       - jpeg=9e=h8ffe710_2
-      - jupyter_core=5.1.0=py39hcbf5309_0
+      - jupyter_core=5.1.5=py39hcbf5309_0
       - kiwisolver=1.4.4=py39h1f6ef14_1
       - krb5=1.20.1=heb0366b_0
       - lcms2=2.14=ha5c8aab_1
       - lerc=4.0.0=h63175ca_0
+      - libaec=1.0.6=h63175ca_1
       - libblas=3.9.0=16_win64_mkl
       - libbrotlicommon=1.0.9=hcfcfb64_8
       - libbrotlidec=1.0.9=hcfcfb64_8
       - libbrotlienc=1.0.9=hcfcfb64_8
       - libcblas=3.9.0=16_win64_mkl
-      - libclang13=15.0.6=default_h77d9078_0
-      - libclang=15.0.6=default_h77d9078_0
+      - libclang13=15.0.7=default_h77d9078_0
+      - libclang=15.0.7=default_h77d9078_0
       - libcurl=7.87.0=h68f0423_0
-      - libdeflate=1.14=hcfcfb64_0
+      - libdeflate=1.17=hcfcfb64_0
       - libffi=3.4.2=h8ffe710_5
       - libglib=2.74.1=he8f3873_1
       - libhwloc=2.8.0=h039e092_1
       - libiconv=1.17=h8ffe710_0
+      - libjpeg-turbo=2.1.4=hcfcfb64_0
       - liblapack=3.9.0=16_win64_mkl
       - libnetcdf=4.8.1=nompi_h8c042bf_106
       - libogg=1.3.4=h8ffe710_1
@@ -1684,7 +1673,7 @@ env_specs:
       - libsodium=1.0.18=h8d14728_1
       - libsqlite=3.40.0=hcfcfb64_0
       - libssh2=1.10.0=h9a1e1f7_3
-      - libtiff=4.5.0=hc4f729c_0
+      - libtiff=4.5.0=hf8721a0_2
       - libvorbis=1.3.7=h0e60522_0
       - libwebp-base=1.2.4=h8ffe710_0
       - libxcb=1.13=hcd874cb_1004
@@ -1692,16 +1681,16 @@ env_specs:
       - libzip=1.9.2=h519de47_1
       - libzlib=1.2.13=hcfcfb64_4
       - llvmlite=0.39.1=py39hd28a505_1
-      - lz4-c=1.9.3=h8ffe710_1
-      - lz4=4.0.2=py39hf617134_0
+      - lz4-c=1.9.4=hcfcfb64_0
+      - lz4=4.2.0=py39hf617134_0
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
       - m2w64-gmp=6.1.0=2
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
-      - markupsafe=2.1.1=py39ha55989b_2
-      - matplotlib-base=3.6.2=py39haf65ace_0
-      - matplotlib=3.6.2=py39hcbf5309_0
+      - markupsafe=2.1.2=py39ha55989b_0
+      - matplotlib-base=3.6.3=py39haf65ace_0
+      - matplotlib=3.6.3=py39hcbf5309_0
       - mkl=2022.1.0=h6a75c08_874
       - msgpack-python=1.0.4=py39h1f6ef14_1
       - msys2-conda-epoch=20160418=1
@@ -1710,28 +1699,28 @@ env_specs:
       - numba=0.56.4=py39h99ae161_0
       - numpy=1.23.5=py39hbccbffa_0
       - openjpeg=2.5.0=ha2aaf27_2
-      - openssl=3.0.7=hcfcfb64_1
-      - pandas=1.5.2=py39h2ba5b7c_0
+      - openssl=3.0.7=hcfcfb64_2
+      - pandas=1.5.3=py39h2ba5b7c_0
       - pandoc=2.19.2=h57928b3_1
       - pcre2=10.40=h17e33f8_0
       - pickleshare=0.7.5=py39hde42818_1002
-      - pillow=9.2.0=py39hcebd2be_4
+      - pillow=9.4.0=py39h9767c21_0
       - ply=3.11=py_1
       - psutil=5.9.4=py39ha55989b_0
       - pthread-stubs=0.4=hcd874cb_1001
       - pthreads-win32=2.9.1=hfa6e2cd_3
-      - pyqt5-sip=12.11.0=py39h99910a6_2
-      - pyqt=5.15.7=py39hb77abff_2
-      - pyrsistent=0.19.2=py39ha55989b_0
+      - pyqt5-sip=12.11.0=py39h99910a6_3
+      - pyqt=5.15.7=py39hb77abff_3
+      - pyrsistent=0.19.3=py39ha55989b_0
       - pysocks=1.7.1=py39hcbf5309_5
       - python=3.9.15=h4de0772_0_cpython
       - pywin32=304=py39h99910a6_2
-      - pywinpty=2.0.9=py39h99910a6_0
+      - pywinpty=2.0.10=py39h99910a6_0
       - pyyaml=6.0=py39ha55989b_5
-      - pyzmq=24.0.1=py39hea35a22_1
-      - qt-main=5.15.6=h9580fe5_5
-      - scipy=1.9.3=py39hfbf2dce_2
-      - sip=6.7.5=py39h99910a6_0
+      - pyzmq=25.0.0=py39hea35a22_0
+      - qt-main=5.15.6=h9580fe5_6
+      - scipy=1.10.0=py39hfbf2dce_0
+      - sip=6.7.6=py39h99910a6_0
       - tbb=2021.7.0=h91493d7_1
       - terminado=0.17.0=pyh08f2357_0
       - tk=8.6.12=h8ffe710_0
@@ -1739,8 +1728,8 @@ env_specs:
       - tornado=6.2=py39ha55989b_1
       - ucrt=10.0.22621.0=h57928b3_0
       - unicodedata2=15.0.0=py39ha55989b_0
-      - vc=14.3=h3d8a991_9
-      - vs2015_runtime=14.32.31332=h1d6e394_9
+      - vc=14.3=hb6edc58_10
+      - vs2015_runtime=14.34.31931=h4c5c07a_10
       - win_inet_pton=1.1.0=py39hcbf5309_5
       - winpty=0.4.3=4
       - xorg-libxau=1.0.9=hcd874cb_0
@@ -1749,4 +1738,4 @@ env_specs:
       - yaml=0.2.5=h8ffe710_2
       - zeromq=4.3.4=h0e60522_1
       - zlib=1.2.13=hcfcfb64_4
-      - zstd=1.5.2=h7755175_4
+      - zstd=1.5.2=h12be248_6

--- a/examples/anaconda-project.yml
+++ b/examples/anaconda-project.yml
@@ -86,6 +86,6 @@ downloads:
     description: Earthquakes
     filename: data/earthquakes-projected.parq
   DATA_3:
-    url: https://github.com/holoviz/holoviz/raw/main/examples/assets/usgs_logo.png
+    url: https://raw.githubusercontent.com/holoviz/holoviz/main/examples/assets/usgs_logo.png
     description: USGS Logo
     filename: data/usgs_logo.png


### PR DESCRIPTION
Enabling libmamba mostly to get better conflict messages. And indeed there were conflicts for a few weeks due
to `jupyter_events` being patched on conda-forge's repodata https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/380. Relocking part of this PR.