### PR TITLE
VOTE: add Scott Christensen to the HoloViz steering committee

### DIFF
--- a/doc/governance/org-docs/STEERING-COMMITTEE.md
+++ b/doc/governance/org-docs/STEERING-COMMITTEE.md
@@ -11,6 +11,7 @@ This document lists the members of the Organization's Steering Committee. Voting
 | Marc Skov Madsen  | [MarcSkovMadsen](https://github.com/MarcSkovMadsen) |
 | Dharhas Pothina  | [dharhas](https://github.com/dharhas) |
 | Rich Signell | [rsignell-usgs](https://github.com/rsignell-usgs) |
+| Scott Christensen | [sdc50](https://github.com/sdc50) |
 
 ---
 This document is based on GitHub MVG-0.1-beta, which is Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
On Jim's request, I have created this PR to add Scott Christensen  ([sdc50](https://github.com/sdc50)) to the HoloViz steering committee.

Per the [HoloViz Org charter](https://github.com/holoviz/holoviz/blob/main/doc/governance/org-docs/CHARTER.md), "Voting members may be added or removed by no less than 3/4 affirmative vote of the Steering Committee."

An affirmative (+1, thumbs up) vote means that you support the candidate's membership on the HoloViz steering committee. 

A negative (-1, thumbs down) vote means that you do not support the candidate's membership on the HoloViz steering committee. 

Please cast a vote by April 5, 2023, 24:00 UTC.

Eligible voters:
@holoviz/steering-committee 
@jbednar @philippjfr @dharhas @jlstevens @sophiamyang @MarcSkovMadsen @rsignell-usgs 
