### PR TITLE
Remove comment on flickering

### DIFF
--- a/examples/tutorial/05_Interactive_Pipelines.ipynb
+++ b/examples/tutorial/05_Interactive_Pipelines.ipynb
@@ -522,8 +522,6 @@
    "id": "298d15b2",
    "metadata": {},
    "source": [
-    "You'll likely notice some flickering as Panel updates the display when the widgets change in value. The flickering comes because the entire plot gets recreated each time the widget is dragged. You can get finer control over such updates, but doing so requires more advanced methods covered in later tutorials, so here, we will just accept that the plot flickers.\n",
-    "\n",
     "## Terminating methods for `.interactive`\n",
     "\n",
     "The examples above all illustrate cases where you can display the output of `.interactive()` and not worry about its type, which is no longer a DataFrame or a HoloViews object, but an `Interactive` object:"


### PR DESCRIPTION
Fixes https://github.com/holoviz/holoviz/issues/364#issuecomment-1614052145

I didn't notice any flickering running moving the widgets of this pipeline, removing the comment.