### PR TITLE
Add Governance to the site

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -77,28 +77,3 @@ HoloViz libraries have been supported by a variety of different funding mechanis
    <div style="text-align:center;">
      <img width="300px" src="https://raw.githubusercontent.com/numfocus/templates/master/images/numfocus-logo.png" alt="NumFOCUS Logo" style="display:inline-block;">
    </div>
-
-
-
-Governance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The HoloViz governance has two levels - the HoloViz Organization
-and the individual HoloViz Projects. This split allows us to stay aligned
-as a community while supporting and benefiting from a diverse set of initiatives.
-
-The governing bodies at the HoloViz Organization level are the Steering Committee
-and Code of Conduct Committee. The Steering Committee is responsible for
-higher-level aspects of the Organization, such as setting the overall scope, vision,
-policy, and direction. Read more about `Organization governance <https://github.com/holoviz/holoviz/blob/main/doc/governance/org-docs/CHARTER.md>`_.
-
-Each HoloViz Project may specify their own governance that is compatible with the HoloViz
-Organization governance. As an example of governance at the HoloViz Project level,
-let's consider this HoloViz.org website Project. The governing body of this Project
-is the Maintainers, one of which is the Project Director, and another may be the
-Lead Maintainer. The Project Director is responsible for the overall direction and
-scope of the Project while a Lead Maintainer is responsible for releases and
-day-to-day technical management of the Project. Read more about the
-`Project Governance <https://github.com/holoviz/holoviz/blob/main/doc/governance/project-docs/GOVERNANCE.md>`_,
-or find the governance for other HoloViz Projects in the appropriate
-repository within the `HoloViz GitHub Organization <https://github.com/holoviz>`_.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,7 @@ ret = subprocess.run([
 ], text=True, capture_output=True, check=True)
 version = release  = base_version(ret.stdout.strip()[1:])
 
+exclude_patterns = ['governance/project-docs/*.md']
 
 html_static_path += ['_static']
 

--- a/doc/governance/index.md
+++ b/doc/governance/index.md
@@ -1,6 +1,13 @@
 # Governance
 
-The Organization Governance covers all HoloViz related efforts, it's described in further details in these sections:
+The HoloViz governance has two levels - the *HoloViz Organization*
+and the individual *HoloViz Projects*. This split allows us to stay aligned
+as a community while supporting and benefiting from a diverse set of initiatives.
+
+The governing bodies at the HoloViz Organization level are the *Steering Committee*
+and *Code of Conduct Committee*. The Steering Committee is responsible for
+higher-level aspects of the Organization, such as setting the overall scope, vision,
+policy, and direction. The *HoloViz Organization* is described in further details in these sections:
 
 ```{toctree}
 :titlesonly:
@@ -13,4 +20,13 @@ org-docs/TRADEMARKS
 org-docs/ANTITRUST
 ```
 
-Each HoloViz Project further adopts and hosts their own Project Governance (e.g. [Datashader Project Governance](https://github.com/holoviz/datashader/blob/main/doc/governance/project-doc/GOVERNANCE.md)) in accordance with the HoloViz Organization Governance.
+Each *HoloViz Project* may specify their own governance that is compatible with the HoloViz
+Organization governance. As an example of governance at the HoloViz Project level,
+let's consider this HoloViz.org website Project. The governing body of this Project
+is the *Maintainers*, one of which is the *Project Director*, and another may be the
+*Lead Maintainer*. The Project Director is responsible for the overall direction and
+scope of the Project while a Lead Maintainer is responsible for releases and
+day-to-day technical management of the Project. Read more about the
+[Project Governance](https://github.com/holoviz/holoviz/blob/main/doc/governance/project-docs/GOVERNANCE.md)
+or find the governance for other HoloViz Projects in the appropriate
+repository within the [HoloViz GitHub Organization](https://github.com/holoviz).

--- a/doc/governance/index.md
+++ b/doc/governance/index.md
@@ -1,0 +1,16 @@
+# Governance
+
+The Organization Governance covers all HoloViz related efforts, it's described in further details in these sections:
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+
+org-docs/CHARTER
+org-docs/STEERING-COMMITTEE
+org-docs/CODE-OF-CONDUCT
+org-docs/TRADEMARKS
+org-docs/ANTITRUST
+```
+
+Each HoloViz Project further adopts and hosts their own Project Governance (e.g. [Datashader Project Governance](https://github.com/holoviz/datashader/blob/main/doc/governance/project-doc/GOVERNANCE.md)) in accordance with the HoloViz Organization Governance.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -93,6 +93,7 @@ If what you see looks relevant to you, you can then follow the steps outlined in
    Blog <https://blog.holoviz.org/>
    Topics <topics/index>
    Contributing <contributing>
+   Governance <governance/index>
    Roadmap <Roadmap>
    FAQ
    About <about>


### PR DESCRIPTION
I thought it'd be a good idea to expose HoloViz's governance docs to the community.

![image](https://github.com/holoviz/holoviz/assets/35924738/33edfc78-7136-4f67-a08d-aab0f260ba39)
![image](https://github.com/holoviz/holoviz/assets/35924738/983b7666-6620-4634-9573-923fb328af73)
![image](https://github.com/holoviz/holoviz/assets/35924738/803cc413-49d8-4240-8d23-3aacae3ea7d2)
