### PR TITLE
Add a custom nav bar with more dropdown menus

### DIFF
--- a/doc/_templates/nav-bar-holoviz.html
+++ b/doc/_templates/nav-bar-holoviz.html
@@ -1,0 +1,85 @@
+<nav class="navbar-nav">
+  <p class="sidebar-header-items__title"
+     role="heading"
+     aria-level="1"
+     aria-label="{{ _('Site Navigation') }}">
+    {{ _("Site Navigation") }}
+  </p>
+
+  <ul class="bd-navbar-elements navbar-nav">
+    <li class="nav-item">
+        <a class="nav-link nav-internal" href="start.html">Start here</a>
+    </li>
+    <div class="nav-item dropdown">
+        <button aria-expanded="false" aria-haspopup="true" class="btn dropdown-toggle nav-item" data-bs-toggle="dropdown" type="button">Learn</button>
+        <div class="dropdown-menu">
+            <li class="nav-item">
+                <a class="nav-link nav-internal" href="learn/tutorial/index.html">Tutorial</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-internal" href="learn/talks/index.html">Talks</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-internal" href="learn/faq.html">FAQ</a>
+            </li>
+        </div>
+    </div>
+    <li class="nav-item">
+        <a class="nav-link nav-external" href="https://examples.holoviz.org/">Examples</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link nav-internal" href="community.html">Community</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link nav-internal" href="contribute.html">Contribute</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link nav-external" href="https://blog.holoviz.org/">Blog</a>
+    </li>
+    <div class="nav-item dropdown">
+        <button aria-expanded="false" aria-haspopup="true" class="btn dropdown-toggle nav-item" data-bs-toggle="dropdown" type="button">About us</button>
+        <div class="dropdown-menu">
+            <li class="nav-item">
+                <a class="nav-link nav-internal" href="about/governance/index.html">Governance</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-internal" href="about/roadmap.html">Roadmap</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-internal" href="about/funding.html">Funding</a>
+            </li>
+        </div>
+    </div>
+    <div class="nav-item dropdown">
+        <button aria-expanded="false" aria-haspopup="true" class="btn dropdown-toggle nav-item" data-bs-toggle="dropdown" type="button">Websites</button>
+        <div class="dropdown-menu">
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://panel.holoviz.org/">Panel</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://hvplot.holoviz.org/">hvPlot</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://holoviews.org/">HoloViews</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://geoviews.org/">GeoViews</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://datashader.org">Datashader</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://lumen.holoviz.org/">Lumen</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://param.holoviz.org/">Param</a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link nav-external" href="https://colorcet.holoviz.org/">Colorcet</a>
+            </li>
+        </div>
+    </div>
+  </ul>
+
+</nav>
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,7 @@ version = release  = base_version(ret.stdout.strip()[1:])
 
 
 html_static_path += ['_static']
+templates_path += ['_templates']
 
 html_theme = "pydata_sphinx_theme"
 html_logo = '_static/holoviz-logo-unstacked.svg'
@@ -35,11 +36,11 @@ html_theme_options.update({
             "icon": "fab fa-discourse",
         },
     ],
-    "header_links_before_dropdown": 6,
     "secondary_sidebar_items": [
         "github-stars-button",
         "page-toc",
     ],
+    "navbar_center": ["nav-bar-holoviz"],
 })
 
 html_context.update({
@@ -48,3 +49,6 @@ html_context.update({
     'github_user': 'holoviz',
     'github_repo': 'holoviz',
 })
+
+# Uncomment to turn off notebook execution.
+nb_execution_mode = "off"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,4 +51,4 @@ html_context.update({
 })
 
 # Uncomment to turn off notebook execution.
-nb_execution_mode = "off"
+# nb_execution_mode = "off"


### PR DESCRIPTION
@droumis I had a quick look and I think in the end it's not too hard to customize the nav bar to have multiple dropdowns.

![image](https://github.com/holoviz/holoviz/assets/35924738/a084a2d9-7f6f-4671-b6a1-f85664413c77)

This PR is not meant to be merged, I think you could use these changes as a basis for your changes to the nav bar (half the relative links in this PR are fake 🙃 ).

I just found the nav bar template for the version we use in this repo (found in the lock file) on the theme's github https://github.com/pydata/pydata-sphinx-theme/blob/v0.13.3/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html. Saved that in a new file. I inspected the HTML of the nav bar on the currently deployed website, copied and adapted it to add more dropdowns and external links. We'll probably have to update the template when bumping the version of the theme, it shouldn't be too hard though.

---

I added a `Websites` dropdown with links to the HoloViz websites. That's because I've been wondering how to better expose HoloViz and its projects on all the websites. Perhaps that dropdown should be added to all the websites? Just a thought!

---

Since we were wondering, in the newer versions of the theme it's possible to customize the text of the `More` dropdown with the `header_dropdown_text` option (https://github.com/pydata/pydata-sphinx-theme/pull/1423). Useful, but not enough for us I think.