### PR TITLE
Update install instructions

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,3 +48,6 @@ html_context.update({
     'github_user': 'holoviz',
     'github_repo': 'holoviz',
 })
+
+# Uncomment to turn off notebook execution.
+# nb_execution_mode = "off"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -87,7 +87,6 @@ If what you see looks relevant to you, you can then follow the steps outlined in
    :maxdepth: 2
 
    Background <background>
-   Installation <installation>
    Talks <talks/index>
    Tutorial <tutorial/index>
    Blog <https://blog.holoviz.org/>

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -20,20 +20,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"admonition alert alert-warning\">\n",
-    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Tutorial Instructions Only!</p>\n",
-    "    The instructions below are specific to this tutorial. If you are looking to install a HoloViz package for your own use, please consult each library's website (linked from <a href=\"https://holoviz.org/\">HoloViz.org</a>) for detailed guidance. Typically, installing these packages simply involves `conda install` or `pip install`.\n",
-    "</div>\n"
+    "```{important} \n",
+    "The instructions below are specific to this tutorial. If you are looking to install a HoloViz package for your own use, please consult each library's website (linked from [HoloViz](https://holoviz.org/)) for detailed guidance. Typically, installing these packages simply involves `conda install` or `pip install`.\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"admonition alert alert-info\">\n",
-    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Get the latest version</p>\n",
-    "    If you are attending a live tutorial or workshop and have previously run through the tutorial, make sure to run these steps again shortly before the live session to ensure you have the same version of the tutorial that the presenter will use.\n",
-    "</div>"
+    "```{hint}\n",
+    "If you are attending a live tutorial or workshop and have previously run through the tutorial, make sure to run these steps again shortly before the live session to ensure you have the same version of the tutorial that the presenter will use.\n",
+    "```"
    ]
   },
   {

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -75,12 +75,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import version_checker\n",
     "import datashader, panel, hvplot, param, holoviews as hv  # noqa\n",
+    "from package_checker import check_packages\n",
     "hv.extension('bokeh', 'matplotlib')\n",
     "\n",
     "packages = ['datashader', 'holoviews', 'panel', 'hvplot', 'param']\n",
-    "version_checker.check_packages(packages)"
+    "check_packages(packages)"
    ]
   },
   {
@@ -96,19 +96,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
-    "import pandas as pd\n",
+    "from data_checker import check_data\n",
     "\n",
-    "print('Data exists:', pathlib.Path('../data/earthquakes-projected.parq').is_file())\n",
-    "\n",
-    "try:    \n",
-    "    columns = ['depth', 'id', 'latitude', 'longitude', 'mag', 'place', 'time', 'type']\n",
-    "    path = pathlib.Path('../data/earthquakes-projected.parq')\n",
-    "    data = pd.read_parquet(path, columns=columns, engine='fastparquet')\n",
-    "    data.head()\n",
-    "    print('Data check successful!')\n",
-    "except RuntimeError as e:\n",
-    "    print('The data cannot be read: %s' % e)\n"
+    "data_path = '../data/earthquakes-projected.parq'\n",
+    "check_data(data_path)"
    ]
   },
   {

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -57,7 +57,7 @@
     "    >> cd holoviz_tutorial\n",
     "    ```\n",
     "\n",
-    "5. **Run the tutorial Launch Jupyter**: Don't be alarmed, this will output many lines as it downloads packages, sets up another conda environment for the tutorial, and then launches Jupyter.\n",
+    "5. **Launch Jupyter**: Don't be alarmed when this command outputs many lines as it downloads packages, sets up another conda environment just for the tutorial, and then launches Jupyter.\n",
     "    ```bash\n",
     "    >> anaconda-project run jupyter lab\n",
     "    ```\n",

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -13,7 +13,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This first step to the tutorial will make sure your system is set up to do all the remaining sections, with all software installed and all data downloaded as needed.  The [index](index.ipynb) provided some links you might want to examine before you start."
+    "This first step to the tutorial will ensure your system is set up to handle all the subsequent sections, with all software installed and all data downloaded as needed. The [index](index.ipynb) provides some links you might want to examine before you start."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"admonition alert alert-warning\">\n",
+    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Tutorial Instructions Only!</p>\n",
+    "    The instructions below are specific to this tutorial. If you are looking to install a HoloViz package for your own use, please consult each library's website (linked from <a href=\"https://holoviz.org/\">HoloViz.org</a>) for detailed guidance. Typically, installing these packages simply involves `conda install` or `pip install`.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"admonition alert alert-info\">\n",
+    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Get the latest version</p>\n",
+    "    If you are attending a live tutorial or workshop and have previously run through the tutorial, make sure to run these steps again shortly before the live session to ensure you have the same version of the tutorial that the presenter will use.\n",
+    "</div>"
    ]
   },
   {
@@ -22,34 +42,31 @@
    "source": [
     "## Getting set up\n",
     "\n",
-    "Please consult [holoviz.org](http://holoviz.org/installation.html) for the full instructions on installing the software used in these tutorials. Here is the condensed version of those instructions, assuming you have already downloaded and installed [Anaconda](https://www.anaconda.com/download) or [Miniconda](https://conda.io/miniconda.html) and have opened a command prompt in a Conda environment:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "conda create -n project \"anaconda-project>=0.11\"\n",
-    "conda activate project\n",
-    "anaconda-project download pyviz/holoviz_tutorial\n",
-    "cd holoviz_tutorial # You may need to delete this directory if you've run the command above before\n",
-    "anaconda-project run jupyter notebook\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you prefer JupyterLab to the default (classic) notebook interface, you can replace \"notebook\" with \"lab\"."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Once your chosen environment is running, navigate to `tutorial/00_Setup.ipynb` (i.e. this notebook) and run the following cell to test the key imports needed for this tutorial. If it completes without errors your environment should be ready to go:"
+    "1. **Install conda**:\n",
+    "   If you don't have conda installed, you can follow the [conda docs](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) to download and install it. We recommend using the [Miniconda](https://conda.io/miniconda.html) installer.\n",
+    "\n",
+    "2. **Open a new terminal window**\n",
+    "   \n",
+    "3. **Create and activate a new conda environment**: This environment is just for `anaconda-project`, a tool to help download the required packages and data for the tutorial.\n",
+    "    ```bash\n",
+    "    >> conda create -n project \"anaconda-project>=0.11\"\n",
+    "    >> conda activate project\n",
+    "    ```\n",
+    "\n",
+    "4. **Download and navigate to the tutorial project**: If you've previously run the `anaconda-project download` command below, you may need to delete or rename the pre-existing `holoviz_tutorial` directory.\n",
+    "    ```bash\n",
+    "    >> anaconda-project download pyviz/holoviz_tutorial\n",
+    "    >> cd holoviz_tutorial\n",
+    "    ```\n",
+    "\n",
+    "5. **Run the tutorial Launch Jupyter**: Don't be alarmed, this will output many lines as it downloads packages, sets up another conda environment for the tutorial, and then launches Jupyter.\n",
+    "    ```bash\n",
+    "    >> anaconda-project run jupyter lab\n",
+    "    ```\n",
+    "    Note: You can replace \"lab\" with \"notebook\" if you prefer the original Jupyter notebook interface.\n",
+    "\n",
+    "5. **Test HoloViz imports**:\n",
+    "After launching Jupyter, navigate to this notebook (`tutorial/00_Setup.ipynb`) and run the following cell. This is a quick check that your environment is set up correctly. You should see the HoloViews, Bokeh, and Matplotlib logos along with a success message.\n"
    ]
   },
   {
@@ -58,45 +75,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import datashader as ds, bokeh, holoviews as hv, panel as pn  # noqa\n",
-    "from packaging.version import Version\n",
+    "import version_checker\n",
+    "import datashader, panel, hvplot, param, holoviews as hv  # noqa\n",
+    "hv.extension('bokeh', 'matplotlib')\n",
     "\n",
-    "min_versions = dict(ds='0.15.1', bokeh='3.2.0', hv='1.16.2', pn='1.2.0')\n",
-    "\n",
-    "for lib, ver in min_versions.items():\n",
-    "    v = globals()[lib].__version__\n",
-    "    if Version(v) < Version(ver):\n",
-    "        print(\"Error: expected {}={}, got {}\".format(lib,ver,v))"
+    "packages = ['datashader', 'holoviews', 'panel', 'hvplot', 'param']\n",
+    "version_checker.check_packages(packages)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And you should see the HoloViews, Bokeh, and Matplotlib logos after running the following cell:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hv.extension('bokeh', 'matplotlib')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Downloading sample data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Lastly, let's make sure the datasets needed are available.  First, check that the large earthquake dataset was downloaded correctly during the `anaconda-project run` command:"
+    "7. **Check datasets**: Finally, run the following cell to make sure the dataset exists and is readable."
    ]
   },
   {
@@ -106,33 +97,18 @@
    "outputs": [],
    "source": [
     "import pathlib\n",
-    "from pyct import cmd\n",
+    "import pandas as pd\n",
     "\n",
-    "if not pathlib.Path('../data/earthquakes-projected.parq').is_file():\n",
-    "    cmd.fetch_data(name='holoviz', path='..') # Alternative way to fetch the data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Make sure that you have the SNAPPY dependency required to read these data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "try:\n",
-    "    import pandas as pd\n",
+    "print('Data exists:', pathlib.Path('../data/earthquakes-projected.parq').is_file())\n",
+    "\n",
+    "try:    \n",
     "    columns = ['depth', 'id', 'latitude', 'longitude', 'mag', 'place', 'time', 'type']\n",
     "    path = pathlib.Path('../data/earthquakes-projected.parq')\n",
     "    data = pd.read_parquet(path, columns=columns, engine='fastparquet')\n",
     "    data.head()\n",
+    "    print('Data check successful!')\n",
     "except RuntimeError as e:\n",
-    "    print('The data cannot be read: %s' % e)"
+    "    print('The data cannot be read: %s' % e)\n"
    ]
   },
   {
@@ -141,6 +117,11 @@
    "source": [
     "If you don't see any error messages above, you should be good to go!  Now that you are set up, you can continue with the [rest of the tutorial sections](01_Overview.ipynb). "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "source": [
     "```{important} \n",
-    "The instructions below are specific to this tutorial. If you are looking to install a HoloViz package for your own use, please consult each library's website (linked from [HoloViz](https://holoviz.org/)) for detailed guidance. Typically, installing these packages simply involves `conda install` or `pip install`.\n",
+    "The instructions below are specific to this tutorial, and are designed to ensure that you install exactly the same versions for which the tutorial was written so that the output shown will exactly match what you see yourself. If you are looking to install a HoloViz package for your own use, please consult each library's website (linked from [HoloViz](https://holoviz.org/)) for detailed guidance. Typically, installing these packages simply involves `conda install` or `pip install`, e.g. `conda install hvplot datashader`.\n",
     "```"
    ]
   },

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -64,7 +64,7 @@
     "    Note: You can replace \"lab\" with \"notebook\" if you prefer the original Jupyter notebook interface.\n",
     "\n",
     "5. **Test HoloViz imports**:\n",
-    "After launching Jupyter, navigate to this notebook (`tutorial/00_Setup.ipynb`) and run the following cell. This is a quick check that your environment is set up correctly. You should see the HoloViews, Bokeh, and Matplotlib logos along with a success message.\n"
+    "After launching Jupyter, navigate to this notebook (`tutorial/00_Setup.ipynb`) and run the following cell. This command is a quick check that your environment is set up correctly. You should see the HoloViews, Bokeh, and Matplotlib logos along with a success message.\n"
    ]
   },
   {

--- a/examples/tutorial/data_checker.py
+++ b/examples/tutorial/data_checker.py
@@ -1,0 +1,23 @@
+import pathlib
+import pandas as pd
+
+def check_data(file_path='../data/earthquakes-projected.parq'):
+    """
+    Checks if the data file exists and reads it.
+
+    Args:
+        file_path (str, optional): The path to the parquet file. Default is '../data/earthquakes-projected.parq'.
+
+    """
+    path = pathlib.Path(file_path)
+    
+    if not path.is_file():
+        print(f"Data file does not exist at {file_path}")
+
+    try:
+        columns = ['depth', 'id', 'latitude', 'longitude', 'mag', 'place', 'time', 'type']
+        data = pd.read_parquet(path, columns=columns, engine='fastparquet')
+        data.head()
+        print("Data exists and is readable!")       
+    except RuntimeError as e:
+        print(f"The data cannot be read: {str(e)}")

--- a/examples/tutorial/package_checker.py
+++ b/examples/tutorial/package_checker.py
@@ -1,0 +1,45 @@
+import yaml
+import pathlib
+import sys
+from packaging.version import Version
+
+def get_required_versions(yaml_path):
+    """
+    Reads the YAML configuration and extracts all package version requirements.
+    
+    Returns:
+        dict: A dictionary mapping package names to their required versions.
+    """
+    yaml_file_path = pathlib.Path(yaml_path)
+    with open(yaml_file_path, 'r') as file:
+        data = yaml.safe_load(file)
+        packages = data['packages']
+        version_dict = {}
+        for package in packages:
+            if '==' in package:
+                pkg, version = package.split('==')
+                version_dict[pkg] = version
+        return version_dict
+
+def check_packages(packages, yaml_path='../anaconda-project.yml'):
+    """
+    Checks if specified packages are installed with correct versions as per the YAML configuration.
+    
+    Args:
+        packages (list): A list of package names to check.
+    """
+    required_versions = get_required_versions(yaml_path)
+    error_found = False
+    for pkg in packages:
+        try:
+            req_version = required_versions[pkg]
+            installed_version = sys.modules[pkg].__version__
+            if Version(installed_version) < Version(req_version):
+                print(f"Error: {pkg} expected version {req_version}, got {installed_version}")
+                error_found = True
+        except KeyError:
+            print(f"{pkg} is not installed or not specified in the YAML configuration.")
+            error_found = True
+
+    if not error_found:
+        print("All specified packages are correctly installed.")


### PR DESCRIPTION
I found the installation instructions to be overly verbose and redundant. 

This PR:
- Rewrites install instructions for tutorial for clarity
- Adds helper functions for package and data checks, reducing complexity exposed in the notebook to a user
- Suggests jupyter lab over notebook
- Removes the largely redundant top level install page and instead adds an admonition on the tutorial setup notebook for non-tutorial followers to defer to the package-specific installation instructions on the individual project websites.

Those that typically lead live tutorials, please review.

New:
![holoviz-dev github io_holoviz_tutorial_Setup html (1)](https://github.com/holoviz/holoviz/assets/6613202/3adb1743-bed4-477e-9404-85eccf496ed8)