### PR TITLE
Unify place to grab path

### DIFF
--- a/examples/talks/Overview.ipynb
+++ b/examples/talks/Overview.ipynb
@@ -684,14 +684,19 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import dask.dataframe as dd\n",
     "from colorcet import palette\n",
     "from holoviews.element.tiles import EsriImagery\n",
     "\n",
+    "sys.path.append(os.getcwd() + '/../tutorial')  # to import data_checker\n",
+    "from data_checker import DATASET_PATHS\n",
+    "\n",
     "topts = hv.opts.Tiles(width=700, height=600, bgcolor='black', \n",
     "                      xaxis=None, yaxis=None, show_grid=False)\n",
     "tiles = EsriImagery().opts(topts) \n",
-    "earthquakes  = dd.read_parquet(Path('../data/earthquakes-projected.parq'), engine='pyarrow').persist()\n",
+    "earthquakes  = dd.read_parquet(DATASET_PATHS['earthquakes'], engine='pyarrow').persist()\n",
     "colormaps = {n: palette[n] for n in ['fire','bgy','bgyw','bmy','gray','kbc']}"
    ]
   },

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -94,9 +94,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from data_checker import check_data\n",
+    "from data_checker import check_data, DATA_DIR\n",
     "\n",
-    "data_path = '../data/earthquakes-projected.parq'\n",
+    "data_path = DATA_DIR / 'earthquakes-projected.parq'\n",
     "check_data(data_path)"
    ]
   },

--- a/examples/tutorial/02_Plotting.ipynb
+++ b/examples/tutorial/02_Plotting.ipynb
@@ -49,7 +49,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
     "import pandas as pd\n",
     "from data_checker import DATASET_PATHS"
    ]
@@ -61,7 +60,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(DATASETS[\"earthquakes\"])"
+    "df = pd.read_parquet(DATASET_PATHS[\"earthquakes\"])"
    ]
   },
   {

--- a/examples/tutorial/02_Plotting.ipynb
+++ b/examples/tutorial/02_Plotting.ipynb
@@ -50,7 +50,8 @@
    "outputs": [],
    "source": [
     "import pathlib\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {
@@ -60,7 +61,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))"
+    "df = pd.read_parquet(DATASETS[\"earthquakes\"])"
    ]
   },
   {

--- a/examples/tutorial/03_Composing_Plots.ipynb
+++ b/examples/tutorial/03_Composing_Plots.ipynb
@@ -35,7 +35,8 @@
    "source": [
     "import pathlib\n",
     "import pandas as pd\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {
@@ -45,7 +46,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))"
+    "df = pd.read_parquet(DATASET_PATHS[\"earthquakes\"])"
    ]
   },
   {
@@ -461,7 +462,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataarray(pathlib.Path('../data/raster/gpw_v4_population_density_rev11_2010_2pt5_min.nc'))\n",
+    "ds = xr.open_dataarray(DATASET_PATHS['population_density'])\n",
     "ds"
    ]
   },

--- a/examples/tutorial/03_Composing_Plots.ipynb
+++ b/examples/tutorial/03_Composing_Plots.ipynb
@@ -33,7 +33,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "from data_checker import DATASET_PATHS"

--- a/examples/tutorial/04_Interlinked_Plots.ipynb
+++ b/examples/tutorial/04_Interlinked_Plots.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))"
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])"
    ]
   },
   {

--- a/examples/tutorial/04_Interlinked_Plots.ipynb
+++ b/examples/tutorial/04_Interlinked_Plots.ipynb
@@ -33,11 +33,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
     "import holoviews as hv\n",
     "import pandas as pd\n",
     "import hvplot.pandas  # noqa\n",
-    "import colorcet as cc"
+    "import colorcet as cc\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {

--- a/examples/tutorial/05_Interactive_Pipelines.ipynb
+++ b/examples/tutorial/05_Interactive_Pipelines.ipynb
@@ -37,13 +37,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
-    "\n",
     "import holoviews as hv\n",
     "import hvplot.pandas # noqa\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import panel as pn\n",
+    "\n",
+    "from data_checker import DATASET_PATHS\n",
     "\n",
     "pn.extension(throttled=True)"
    ]

--- a/examples/tutorial/05_Interactive_Pipelines.ipynb
+++ b/examples/tutorial/05_Interactive_Pipelines.ipynb
@@ -117,7 +117,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "df.index = df.index.tz_localize(None)"
    ]
   },

--- a/examples/tutorial/06_Dashboards.ipynb
+++ b/examples/tutorial/06_Dashboards.ipynb
@@ -156,7 +156,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "df.index = df.index.tz_localize(None)\n",
     "df = df.reset_index()\n",
     "\n",
@@ -171,7 +171,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "ds = xr.open_dataarray(pathlib.Path('../data/raster/gpw_v4_population_density_rev11_2010_2pt5_min.nc'))\n",
+    "ds = xr.open_dataarray(DATASET_PATHS['population_density'])\n",
     "cleaned_ds = ds.where(ds.values != ds.nodatavals).sel(band=1)\n",
     "cleaned_ds.name = 'population'"
    ]

--- a/examples/tutorial/06_Dashboards.ipynb
+++ b/examples/tutorial/06_Dashboards.ipynb
@@ -39,7 +39,9 @@
     "\n",
     "import colorcet as cc\n",
     "import hvplot.xarray # noqa\n",
-    "import hvplot.pandas # noqa"
+    "import hvplot.pandas # noqa\n",
+    "\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {

--- a/examples/tutorial/06_Dashboards.py
+++ b/examples/tutorial/06_Dashboards.py
@@ -1,13 +1,14 @@
-import pathlib
 import pandas as pd
 import panel as pn
 import holoviews as hv
+
+from data_checker import DATASET_PATHS
 
 pn.extension('tabulator', template='bootstrap', sizing_mode='stretch_width')
 
 import hvplot.pandas # noqa
 
-df = pd.read_parquet(pathlib.Path(__file__).parent.parent / 'data' / 'earthquakes-projected.parq')
+df = pd.read_parquet(DATASET_PATHS['earthquakes'])
 df.index = df.index.tz_localize(None)
 df = df.reset_index()
 

--- a/examples/tutorial/07_Custom_Interactivity.ipynb
+++ b/examples/tutorial/07_Custom_Interactivity.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "most_severe = df[df.mag >= 7]"
    ]
   },

--- a/examples/tutorial/07_Custom_Interactivity.ipynb
+++ b/examples/tutorial/07_Custom_Interactivity.ipynb
@@ -33,7 +33,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import hvplot.pandas  # noqa\n",

--- a/examples/tutorial/07_Custom_Interactivity.ipynb
+++ b/examples/tutorial/07_Custom_Interactivity.ipynb
@@ -37,7 +37,9 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import hvplot.pandas  # noqa\n",
-    "from holoviews.element import tiles"
+    "from holoviews.element import tiles\n",
+    "\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {

--- a/examples/tutorial/07_Custom_Interactivity.py
+++ b/examples/tutorial/07_Custom_Interactivity.py
@@ -10,8 +10,10 @@ hv.extension("bokeh")
 
 import panel as pn
 
+from data_checker import DATASET_PATHS
 
-df = pd.read_parquet(pathlib.Path(__file__).parent.parent / 'data' / 'earthquakes-projected.parq')
+
+df = pd.read_parquet(DATASET_PATHS['earthquakes'])
 
 most_severe = df[df.mag >= 7]
 high_mag_quakes = most_severe.hvplot.points(x='easting', y='northing', c='mag', 

--- a/examples/tutorial/07_Custom_Interactivity.py
+++ b/examples/tutorial/07_Custom_Interactivity.py
@@ -1,4 +1,3 @@
-import pathlib
 import pandas as pd
 import hvplot.pandas  # noqa
 from holoviews.element import tiles

--- a/examples/tutorial/08_Custom_Dashboards.ipynb
+++ b/examples/tutorial/08_Custom_Dashboards.ipynb
@@ -38,7 +38,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'), columns=['time', 'place', 'mag'])\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'], columns=['time', 'place', 'mag'])\n",
     "df = df.reset_index()\n",
     "df['time'] = df.time.dt.strftime('%m/%d/%Y %H:%M:%S') "
    ]

--- a/examples/tutorial/08_Custom_Dashboards.ipynb
+++ b/examples/tutorial/08_Custom_Dashboards.ipynb
@@ -18,6 +18,8 @@
     "import pathlib\n",
     "import panel as pn\n",
     "\n",
+    "from data_checker import DATASET_PATHS\n",
+    "\n",
     "pn.extension()"
    ]
   },

--- a/examples/tutorial/08_Custom_Dashboards.ipynb
+++ b/examples/tutorial/08_Custom_Dashboards.ipynb
@@ -15,7 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pathlib\n",
     "import panel as pn\n",
     "\n",
     "from data_checker import DATASET_PATHS\n",

--- a/examples/tutorial/09_Advanced_Dashboards.ipynb
+++ b/examples/tutorial/09_Advanced_Dashboards.ipynb
@@ -34,6 +34,8 @@
     "import hvplot.pandas # noqa: API import\n",
     "import hvplot.xarray # noqa: API import\n",
     "\n",
+    "from data_checker import DATASET_PATHS\n",
+    "\n",
     "pn.extension()"
    ]
   },

--- a/examples/tutorial/09_Advanced_Dashboards.ipynb
+++ b/examples/tutorial/09_Advanced_Dashboards.ipynb
@@ -51,11 +51,11 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "\n",
     "most_severe = df[df.mag >= 7]\n",
     "\n",
-    "ds = xr.open_dataarray(pathlib.Path('../data/raster/gpw_v4_population_density_rev11_2010_2pt5_min.nc'))\n",
+    "ds = xr.open_dataarray(DATASET_PATHS['population_density'])\n",
     "cleaned_ds = ds.where(ds.values != ds.nodatavals).sel(band=1)\n",
     "cleaned_ds.name = 'population'\n",
     "\n",

--- a/examples/tutorial/09_Advanced_Dashboards.py
+++ b/examples/tutorial/09_Advanced_Dashboards.py
@@ -13,7 +13,9 @@ pn.extension()
 
 from holoviews.streams import Selection1D
 
-df = pd.read_parquet(pathlib.Path(__file__).parent.parent / 'data' / 'earthquakes-projected.parq')
+from data_checker import DATASET_PATHS
+
+df = pd.read_parquet(DATASET_PATHS['earthquakes'])
 
 most_severe = df[df.mag >= 7]
 

--- a/examples/tutorial/data_checker.py
+++ b/examples/tutorial/data_checker.py
@@ -1,7 +1,16 @@
 import pathlib
 import pandas as pd
 
-def check_data(file_path='../data/earthquakes-projected.parq'):
+THIS_DIR = pathlib.Path(__file__).parent
+DATA_DIR = THIS_DIR / '..' / 'data'
+DATASET_PATHS = {
+    "earthquakes": DATA_DIR / 'earthquakes-projected.parq',
+    "population_density": DATA_DIR / 'raster' / 'gpw_v4_population_density_rev11_2010_2pt5_min.nc',
+    
+}
+
+
+def check_data(file_path=DATASET_PATHS["earthquakes"]):
     """
     Checks if the data file exists and reads it.
 

--- a/examples/tutorial/exercises/Advanced_Dashboarding.ipynb
+++ b/examples/tutorial/exercises/Advanced_Dashboarding.ipynb
@@ -28,6 +28,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import pathlib\n",
     "import colorcet as cc # noqa\n",
     "import holoviews as hv # noqa\n",
@@ -38,6 +40,9 @@
     "\n",
     "import hvplot.pandas # noqa: API import\n",
     "import hvplot.xarray # noqa: API import\n",
+    "\n",
+    "sys.path.append(os.getcwd() + '/..')  # to import data_checker\n",
+    "from data_checker import DATASET_PATHS\n",
     "\n",
     "pn.extension()"
    ]
@@ -56,7 +61,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))"
+    "df = pd.read_parquet(DATASET_PATHS[\"earthquakes\"])"
    ]
   },
   {

--- a/examples/tutorial/exercises/Advanced_Dashboarding.ipynb
+++ b/examples/tutorial/exercises/Advanced_Dashboarding.ipynb
@@ -30,7 +30,6 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "import pathlib\n",
     "import colorcet as cc # noqa\n",
     "import holoviews as hv # noqa\n",
     "import numpy as np # noqa\n",
@@ -61,7 +60,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(DATASET_PATHS[\"earthquakes\"])"
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])"
    ]
   },
   {
@@ -70,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataarray(pathlib.Path('../../data/raster/gpw_v4_population_density_rev11_2010_2pt5_min.nc'))\n",
+    "ds = xr.open_dataarray(DATASET_PATHS['population_density'])\n",
     "cleaned_ds = ds.where(ds.values != ds.nodatavals).sel(band=1)\n",
     "cleaned_ds.name = 'population'"
    ]

--- a/examples/tutorial/exercises/Building_Pipelines.ipynb
+++ b/examples/tutorial/exercises/Building_Pipelines.ipynb
@@ -27,13 +27,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import pathlib\n",
     "import pandas as pd\n",
     "import xarray as xr\n",
     "import panel as pn  # noqa\n",
     "\n",
     "import hvplot.pandas # noqa: adds hvplot method to pandas objects\n",
-    "import hvplot.xarray # noqa: adds hvplot method to xarray objects"
+    "import hvplot.xarray # noqa: adds hvplot method to xarray objects\n",
+    "\n",
+    "sys.path.append(os.getcwd() + '/..')  # to import data_checker\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {
@@ -43,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "columns = ['mag', 'depth', 'latitude', 'longitude', 'place', 'type']\n",
     "df = df[columns]\n",
     "most_severe = df[df.mag >= 7]"
@@ -266,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw_ds = xr.open_dataarray(pathlib.Path('../../data/raster/gpw_v4_population_density_rev11_2010_2pt5_min.nc'))\n",
+    "raw_ds = xr.open_dataarray(DATASET_PATHS['population_density'])\n",
     "cleaned_ds = raw_ds.where(raw_ds.values != raw_ds.nodatavals).sel(band=1)\n",
     "cleaned_ds = cleaned_ds.rename({'x': 'longitude','y': 'latitude'})\n",
     "cleaned_ds.name = 'population'\n",

--- a/examples/tutorial/exercises/Building_Pipelines.ipynb
+++ b/examples/tutorial/exercises/Building_Pipelines.ipynb
@@ -29,7 +29,6 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "import pathlib\n",
     "import pandas as pd\n",
     "import xarray as xr\n",
     "import panel as pn  # noqa\n",

--- a/examples/tutorial/exercises/Building_a_Dashboard.ipynb
+++ b/examples/tutorial/exercises/Building_a_Dashboard.ipynb
@@ -15,13 +15,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import pathlib\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import panel as pn\n",
     "pn.extension('katex')\n",
     "\n",
-    "import hvplot.pandas # noqa"
+    "import hvplot.pandas # noqa\n",
+    "\n",
+    "sys.path.append(os.getcwd() + '/..')  # to import data_checker\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {
@@ -40,7 +45,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "columns = ['mag', 'depth', 'latitude', 'longitude', 'place', 'type']\n",
     "df = df[columns]\n",
     "most_severe = df[df.mag >= 7]"

--- a/examples/tutorial/exercises/Linking_Plots.ipynb
+++ b/examples/tutorial/exercises/Linking_Plots.ipynb
@@ -29,7 +29,6 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "import pathlib\n",
     "import pandas as pd\n",
     "import holoviews as hv # noqa\n",
     "\n",

--- a/examples/tutorial/exercises/Linking_Plots.ipynb
+++ b/examples/tutorial/exercises/Linking_Plots.ipynb
@@ -27,12 +27,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import pathlib\n",
     "import pandas as pd\n",
     "import holoviews as hv # noqa\n",
     "\n",
     "import hvplot.pandas # noqa: adds hvplot method to pandas objects\n",
-    "import hvplot.xarray # noqa: adds hvplot method to xarray objects"
+    "import hvplot.xarray # noqa: adds hvplot method to xarray objects\n",
+    "\n",
+    "sys.path.append(os.getcwd() + '/..')  # to import data_checker\n",
+    "from data_checker import DATASET_PATHS"
    ]
   },
   {
@@ -42,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "most_severe = df[df.mag >= 7]"
    ]
   },

--- a/examples/tutorial/exercises/Plotting.ipynb
+++ b/examples/tutorial/exercises/Plotting.ipynb
@@ -28,7 +28,6 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "import pathlib\n",
     "import pandas as pd \n",
     "import xarray as xr\n",
     "\n",

--- a/examples/tutorial/exercises/Plotting.ipynb
+++ b/examples/tutorial/exercises/Plotting.ipynb
@@ -26,6 +26,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import pathlib\n",
     "import pandas as pd \n",
     "import xarray as xr\n",
@@ -33,7 +35,10 @@
     "import hvplot.pandas # noqa: adds hvplot method to pandas objects\n",
     "import hvplot.xarray # noqa: adds hvplot method to xarray objects\n",
     "\n",
-    "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))\n",
+    "sys.path.append(os.getcwd() + '/..')  # to import data_checker\n",
+    "from data_checker import DATASET_PATHS\n",
+    "\n",
+    "df = pd.read_parquet(DATASET_PATHS['earthquakes'])\n",
     "most_severe = df[df.mag >= 7]"
    ]
   },
@@ -50,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataarray(pathlib.Path('../../data/raster/gpw_v4_population_density_rev11_2010_2pt5_min.nc'))\n",
+    "ds = xr.open_dataarray(DATASET_PATHS['population_density'])\n",
     "cleaned_ds = ds.where(ds.values != ds.nodatavals).sel(band=1)\n",
     "cleaned_ds.name = 'population'"
    ]


### PR DESCRIPTION
Working on Nebari preparing Scipy tutorial and realized that unless we want all the participants to download the data (on slow conference wifi), we should allow them to easily point the path to the `shared/` data directory.

Alternatively, we can have a bash script to copy data from the `shared/` directory:
`cp -r $HOME/shared/scipy/hvplot-and-panel/* $HOME/tutorials/holoviz/examples/data`