### PR TITLE
Fix TZ issue

### DIFF
--- a/examples/tutorial/exercises/Linking_Plots.ipynb
+++ b/examples/tutorial/exercises/Linking_Plots.ipynb
@@ -43,6 +43,7 @@
    "outputs": [],
    "source": [
     "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))\n",
+    "df.index = df.index.tz_localize(None)  # to prevent error in comparison\n",
     "most_severe = df[df.mag >= 7]"
    ]
   },


### PR DESCRIPTION
```
linked_selection aborted because it could not display selection for all elements: Invalid comparison between dtype=datetime64[ns, UTC] and datetime64.
```
To reproduce, box select after running:
```python
import pathlib
import pandas as pd
import holoviews as hv # noqa

import hvplot.pandas # noqa: adds hvplot method to pandas objects
import hvplot.xarray # noqa: adds hvplot method to xarray objects

df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))
most_severe = df[df.mag >= 7]

ls = hv.link_selections.instance()

lat_scatter = most_severe.hvplot(
     x='time', y='latitude', kind='scatter', color='red', marker='+', responsive=True, height=300)

lon_scatter = most_severe.hvplot(
         x='time', y='longitude', kind='scatter', color='blue', marker='x', responsive=True, height=300)

ls(lon_scatter + lat_scatter)
```
