### PR TITLE
Reset index

### DIFF
--- a/examples/tutorial/exercises/Linking_Plots.ipynb
+++ b/examples/tutorial/exercises/Linking_Plots.ipynb
@@ -44,6 +44,7 @@
    "source": [
     "df = pd.read_parquet(pathlib.Path('../../data/earthquakes-projected.parq'))\n",
     "df.index = df.index.tz_localize(None)  # to prevent error in comparison\n",
+    "df = df.reset_index()\n",
     "most_severe = df[df.mag >= 7]"
    ]
   },


### PR DESCRIPTION
Without it when trying to use `describe` on selected plot:


```
KeyError: "One or more dimensions in the expression (dim('time')>=np.datetime64('2010-03-11T01:43:21.423041'))&(dim('time')<=np.datetime64('2011-04-01T20:53:28.099845')) could not resolve on ':Dataset   [depth,depthError,dmin,gap,horizontalError,id,latitude,locationSource,longitude,mag,magError,magNst,magSource,magType,net,nst,place,rms,status,type,updated,easting,northing]'. Ensure all dimensions referenced by the expression are present on the supplied object."
```