### PR TITLE
Remove Sophia Yang from Steering Committee

### DIFF
--- a/doc/about/governance/org-docs/STEERING-COMMITTEE.md
+++ b/doc/about/governance/org-docs/STEERING-COMMITTEE.md
@@ -7,7 +7,6 @@ This document lists the members of the Organization's Steering Committee. Voting
 | James Bednar | [jbednar](https://github.com/jbednar) |
 | Philipp Rudiger  | [philippjfr](https://github.com/philippjfr) |
 | Jean-Luc Stevens  | [jlstevens](https://github.com/jlstevens) |
-| Sophia Yang  | [sophiamyang](https://github.com/sophiamyang) |
 | Marc Skov Madsen  | [MarcSkovMadsen](https://github.com/MarcSkovMadsen) |
 | Dharhas Pothina  | [dharhas](https://github.com/dharhas) |
 | Rich Signell | [rsignell-usgs](https://github.com/rsignell-usgs) |


### PR DESCRIPTION
Sophia Yang has resigned from the HoloViz Steering Committee, per Section 4.1 of the Charter. 

Her resignation was communicated to Jim Bednar in writing and verbally relayed to the Steering Committee at the March 27, 2026 meeting.

This PR removes her entry from the Steering Committee membership list.

Requesting review from @sophiamyang or @jbednar to confirm.