### PR TITLE
Split the contributing docs

### DIFF
--- a/doc/contribute/index.md
+++ b/doc/contribute/index.md
@@ -1,0 +1,136 @@
+# General Contributing Guidelines
+
+This guide includes general guidelines on how to contribute to HoloViz. Read the [Operating Guide](#operating-guide) if you are interested in learning how an Open-Source project like HoloViz operates.
+
+## Contributing? Yes! Wait, but why?
+
+There are many reasons why you would want to contribute to the HoloViz project, including:
+
+* You appreciate the HoloViz project, its mission and values, and would like to help
+* You are a user of one of the HoloViz packages and need a bug to be fixed or a new feature to be implemented, and you are willing to tackle that in some ways
+* You are looking for some open-source experience
+* You have been reading one of the HoloViz websites and found something to improve, even just a simple typo
+
+These reasons, or whatever reason brought you here, are all valid in our eyes. We **welcome anyone** who wishes to contribute, and as you will see, there are **many** ways to contribute!
+
+```{hint}
+Contributing to the HoloViz project might even get you a job, which has been the case for a couple of HoloViz members.
+```
+
+## Using AI README
+
+**Maintainers are humans and have finite time and energy to review contributions**. As such, they need to prioritize their work, and they may not have the time to review all contributions. We will be especially reluctant to take time to review submissions that seem to be of low effort on the part of the submitter. Conversely, we especially value contributions that arise from real user use cases, i.e. actually using HoloViz packages like Lumen, Panel, HoloViews, hvPlot, Datashader, and others to build something you care about, but encounter a bug or missing feature.
+
+If you are a new contributor and are contributing a PR though, you can use AI tools, **but you must follow these rules in the PR description**:
+
+- Follow the repos' PR template
+- Explain what motivated the PR (were you trying to achieve something, but encountered ...?)
+- Do NOT list out what changed, unless you want to bring attention to specific changes
+- Include reproduction steps, ideally a Minimal Reproducible Verifiable Example
+- Screenshots or screen recordings (before changes and after changes) must be included
+- Cite sources and docs you referenced with working links
+- Do NOT copy full output of AI summary and instead curate a description yourself
+
+Please limit to 2 open PRs at a time across our repos; if you have more than 2 open PRs, they may be closed, especially if it is your first time contributing to HoloViz.
+
+Separately, please refrain from tagging maintainers shortly after opening a PR/issue, as reviews will happen when time allows. Only bump a PR/issue that has been open for a longer period of time (weeks) without a response.
+
+Maintainers reserve the right to close PRs they deem low-effort or AI-generated without review.
+
+Remember, contributions don't just have to be Pull Request(s) (PR)s either! Filing bugs, helping others on Discord or Discourse, writing blog posts, or sharing things you built on social media all count! See below for more ideas!
+
+As an example, Andrew saw a cool chart online and tried to reproduce it with HoloViews, but noticed that the labels' text color doesn't cycle through alongside the points' color. This motivated him to [create an issue to report it](https://github.com/holoviz/holoviews/issues/5887) and separately [create a PR to fix it](https://github.com/holoviz/holoviews/pull/5888).
+
+Let's continue building a meaningful community!
+
+## What and how to contribute?
+
+If you end up on this page it is quite likely that you are interested in contributing code to HoloViz. However, as you will see, there are many other areas where you could contribute, and in some of these areas, the HoloViz project would really appreciate some help!
+
+### Documentation
+
+Each core HoloViz package has its own website. Maintaining the content of these websites is a lot of work, and you can easily help by:
+
+* Submitting a Pull Request (PR) to fix a typo
+* Submitting a PR to clarify a section
+* Submitting a PR to document an undocumented feature
+* Submitting a PR to update a section that should have been updated
+
+How the websites look and feel can also be improved. If you happen to have some front-end development expertise, your help would be greatly appreciated.
+
+Finally, the documentation also lies within the code, and in Python, it is found in the so-called *docstrings* that accompany modules, classes, methods and functions. You can easily improve the docstrings by:
+
+* Submitting a PR to fix a typo
+* Submitting a PR to clarify a definition
+* Submitting a PR to fix or document the default value of a parameter
+
+```{tip}
+Documentation fixes/improvements that are of a small scope usually do not need an issue to be opened beforehand. If you don't have the time to open a pull request, we would appreciate it if you could record your suggestion in an issue on Github. That would already be an excellent contribution!
+```
+
+### Support
+
+HoloViz users are recommended to ask their usage questions on the [HoloViz Discourse Forum](https://discourse.holoviz.org/). This forum is only helpful if questions can find answers, and you can be the one writing that answer, which will make somebody else's life so much easier! The HoloViz team members monitor the forum and try to contribute regularly, yet the more we are, the better.
+
+```{tip}
+Answering questions on the HoloViz Discourse Forum, or even just trying to answer some random questions, is a very good way to learn how to use the HoloViz tools.
+```
+
+Some users also ask questions on [StackOverflow](https://stackoverflow.com/), which isn't much monitored by the HoloViz team, so we would greatly appreciate any help there.
+
+### Outreach
+
+Before addressing how to contribute code to HoloViz, it is important to mention that a beneficial way to contribute to HoloViz is by communicating more about it. Tweeting, writing blog posts, creating Youtube videos, presenting your work with one or more of the HoloViz tools, etc., are all outreach activities that serve the purpose of HoloViz.
+
+### Code
+
+Contributing code includes:
+
+* fixing an existing bug: the recommended practice is to add one or more unit test(s) that would have failed before the bug fix was implemented.
+* adding a new feature: again, the recommended practice is to add unit test(s) to test the new feature's functionality.
+* improving performance: while slow code isn't necessarily a bug, users always appreciate faster code. Performance improvements should be demonstrated by some benchmark comparing the performance before and after the changes.
+* adding tests: test coverage can always be improved. Adding tests is a good way for beginners to contribute to a project and familiarize themselves with its code base and workflows.
+* refactoring: refactoring can be a good way to improve a code base.
+
+### Developer Instructions
+
+
+```{note}
+The HoloViz projects usually provide specific instructions on how to set up your environment to be ready to contribute documentation or code to the project. The instructions provided hereafter are meant to be general enough to apply to each project. Refer to the documentation of the project you are working on for more details.
+```
+
+Before making anything beyond a minimal contribution (e.g., fixing a typo), the first step is usually to open a [GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) that documents what you are trying to fix/improve. Writing a good issue is important and will affect how it is going to be perceived by the project maintainers, contributors and watchers. Read for instance this [blog post](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) that describes what a good issue should look like.  Once an issue is opened, a discussion can take place with the maintainers to see if what is suggested is relevant, which can guide the next steps.
+
+#### Getting Started
+
+The first step to working on any source code is to install Git as the source codes are stored in [Git](https://git-scm.com) source control repositories. To install Git on any platform, refer to the [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) section of the [Pro Git Book](https://git-scm.com/book/en/v2).
+
+As an external contributor, you do not have permission to submit code directly to any of the repositories. Github offers you the ability to fork the repository, which will create a copy of the repository, on which you will have the right to work freely. Follow [these instructions](https://docs.github.com/en/get-started/quickstart/fork-a-repo) to find out how to fork and clone a repository.
+
+#### Environment Setup
+
+The HoloViz developers rely on [Pixi](https://pixi.sh/latest), a developer tool that facilitates maintaining all of the HoloViz projects. See [Pixi](#pixi-guide) for more details.
+
+#### Contributing Changes
+
+After you have cloned the repo and set up Pixi, the next step is to create a branch and start making changes. Before committing these changes, make sure the tests still pass by running `pixi run test-unit` and that the code meets style guidelines by running `pixi run lint`. Once you are done with your changes, you can commit them. It is good practice to break down big changes into smaller chunks, and each chunk has its own commit with a message that summarizes it.
+
+#### Submitting Your Contribution
+
+Now you can push the branch to your clone and create a *pull request* from your clone to the original repository. This [Github Gist](https://gist.github.com/Chaser324/ce0505fbed06b947d962) describes these GitHub steps in more detail.
+
+The *pull request* you make should reference the *issue* you are attempting to close (i.e. `Fixes #issuenumber`) and include a description of the changes you made.
+See [linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) for more detailed instructions on how to do that. Changes affecting the visual properties should include screenshots or GIFs.
+
+Your *pull request* should now be reviewed by one of the project's maintainers. This may take a while given how busy the maintainers are, so try to be patient :). Your pull request will be evaluated to ensure that it is within the scope of the project (again, it's a good idea to create an issue first to outline your intent and give the maintainers an opportunity to weigh in before you spend the effort creating a pull request). If it's decided to proceed, the review will be conducted, and once the review is done you may be required to make some changes. You may also be asked to *resolve conflicts* if the changes you made appear to conflict with changes made to the source code after you submitted the *pull request*.
+
+When your PR is merged, enjoy, and repeat!
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+:titlesonly:
+
+General Contributing Guidelines <self>
+Operating guide for maintainers <operating_guide>
+```

--- a/doc/contribute/operating_guide.md
+++ b/doc/contribute/operating_guide.md
@@ -1,135 +1,5 @@
-# General Contributing Guidelines
-
-This guide includes general guidelines on how to contribute to HoloViz. Read the [Operating Guide](#operating-guide) if you are interested in learning how an Open-Source project like HoloViz operates.
-
-## Contributing? Yes! Wait, but why?
-
-There are many reasons why you would want to contribute to the HoloViz project, including:
-
-* You appreciate the HoloViz project, its mission and values, and would like to help
-* You are a user of one of the HoloViz packages and need a bug to be fixed or a new feature to be implemented, and you are willing to tackle that in some ways
-* You are looking for some open-source experience
-* You have been reading one of the HoloViz websites and found something to improve, even just a simple typo
-
-These reasons, or whatever reason brought you here, are all valid in our eyes. We **welcome anyone** who wishes to contribute, and as you will see, there are **many** ways to contribute!
-
-```{hint}
-Contributing to the HoloViz project might even get you a job, which has been the case for a couple of HoloViz members.
-```
-
-## Using AI README
-
-**Maintainers are humans and have finite time and energy to review contributions**. As such, they need to prioritize their work, and they may not have the time to review all contributions. We will be especially reluctant to take time to review submissions that seem to be of low effort on the part of the submitter. Conversely, we especially value contributions that arise from real user use cases, i.e. actually using HoloViz packages like Lumen, Panel, HoloViews, hvPlot, Datashader, and others to build something you care about, but encounter a bug or missing feature.
-
-If you are a new contributor and are contributing a PR though, you can use AI tools, **but you must follow these rules in the PR description**:
-
-- Follow the repos' PR template
-- Explain what motivated the PR (were you trying to achieve something, but encountered ...?)
-- Do NOT list out what changed, unless you want to bring attention to specific changes
-- Include reproduction steps, ideally a Minimal Reproducible Verifiable Example
-- Screenshots or screen recordings (before changes and after changes) must be included
-- Cite sources and docs you referenced with working links
-- Do NOT copy full output of AI summary and instead curate a description yourself
-
-Please limit to 2 open PRs at a time across our repos; if you have more than 2 open PRs, they may be closed, especially if it is your first time contributing to HoloViz.
-
-Separately, please refrain from tagging maintainers shortly after opening a PR/issue, as reviews will happen when time allows. Only bump a PR/issue that has been open for a longer period of time (weeks) without a response.
-
-Maintainers reserve the right to close PRs they deem low-effort or AI-generated without review.
-
-Remember, contributions don't just have to be Pull Request(s) (PR)s either! Filing bugs, helping others on Discord or Discourse, writing blog posts, or sharing things you built on social media all count! See below for more ideas!
-
-As an example, Andrew saw a cool chart online and tried to reproduce it with HoloViews, but noticed that the labels' text color doesn't cycle through alongside the points' color. This motivated him to [create an issue to report it](https://github.com/holoviz/holoviews/issues/5887) and separately [create a PR to fix it](https://github.com/holoviz/holoviews/pull/5888).
-
-Let's continue building a meaningful community!
-
-## What and how to contribute?
-
-If you end up on this page it is quite likely that you are interested in contributing code to HoloViz. However, as you will see, there are many other areas where you could contribute, and in some of these areas, the HoloViz project would really appreciate some help!
-
-### Documentation
-
-Each core HoloViz package has its own website. Maintaining the content of these websites is a lot of work, and you can easily help by:
-
-* Submitting a Pull Request (PR) to fix a typo
-* Submitting a PR to clarify a section
-* Submitting a PR to document an undocumented feature
-* Submitting a PR to update a section that should have been updated
-
-How the websites look and feel can also be improved. If you happen to have some front-end development expertise, your help would be greatly appreciated.
-
-Finally, the documentation also lies within the code, and in Python, it is found in the so-called *docstrings* that accompany modules, classes, methods and functions. You can easily improve the docstrings by:
-
-* Submitting a PR to fix a typo
-* Submitting a PR to clarify a definition
-* Submitting a PR to fix or document the default value of a parameter
-
-```{tip}
-Documentation fixes/improvements that are of a small scope usually do not need an issue to be opened beforehand. If you don't have the time to open a pull request, we would appreciate it if you could record your suggestion in an issue on Github. That would already be an excellent contribution!
-```
-
-### Support
-
-HoloViz users are recommended to ask their usage questions on the [HoloViz Discourse Forum](https://discourse.holoviz.org/). This forum is only helpful if questions can find answers, and you can be the one writing that answer, which will make somebody else's life so much easier! The HoloViz team members monitor the forum and try to contribute regularly, yet the more we are, the better.
-
-```{tip}
-Answering questions on the HoloViz Discourse Forum, or even just trying to answer some random questions, is a very good way to learn how to use the HoloViz tools.
-```
-
-Some users also ask questions on [StackOverflow](https://stackoverflow.com/), which isn't much monitored by the HoloViz team, so we would greatly appreciate any help there.
-
-### Outreach
-
-Before addressing how to contribute code to HoloViz, it is important to mention that a beneficial way to contribute to HoloViz is by communicating more about it. Tweeting, writing blog posts, creating Youtube videos, presenting your work with one or more of the HoloViz tools, etc., are all outreach activities that serve the purpose of HoloViz.
-
-### Code
-
-Contributing code includes:
-
-* fixing an existing bug: the recommended practice is to add one or more unit test(s) that would have failed before the bug fix was implemented.
-* adding a new feature: again, the recommended practice is to add unit test(s) to test the new feature's functionality.
-* improving performance: while slow code isn't necessarily a bug, users always appreciate faster code. Performance improvements should be demonstrated by some benchmark comparing the performance before and after the changes.
-* adding tests: test coverage can always be improved. Adding tests is a good way for beginners to contribute to a project and familiarize themselves with its code base and workflows.
-* refactoring: refactoring can be a good way to improve a code base.
-
-### Developer Instructions
-
-
-```{note}
-The HoloViz projects usually provide specific instructions on how to set up your environment to be ready to contribute documentation or code to the project. The instructions provided hereafter are meant to be general enough to apply to each project. Refer to the documentation of the project you are working on for more details.
-```
-
-Before making anything beyond a minimal contribution (e.g., fixing a typo), the first step is usually to open a [GitHub Issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues) that documents what you are trying to fix/improve. Writing a good issue is important and will affect how it is going to be perceived by the project maintainers, contributors and watchers. Read for instance this [blog post](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) that describes what a good issue should look like.  Once an issue is opened, a discussion can take place with the maintainers to see if what is suggested is relevant, which can guide the next steps.
-
-#### Getting Started
-
-The first step to working on any source code is to install Git as the source codes are stored in [Git](https://git-scm.com) source control repositories. To install Git on any platform, refer to the [Installing Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) section of the [Pro Git Book](https://git-scm.com/book/en/v2).
-
-As an external contributor, you do not have permission to submit code directly to any of the repositories. Github offers you the ability to fork the repository, which will create a copy of the repository, on which you will have the right to work freely. Follow [these instructions](https://docs.github.com/en/get-started/quickstart/fork-a-repo) to find out how to fork and clone a repository.
-
-#### Environment Setup
-
-The HoloViz developers rely on [Pixi](https://pixi.sh/latest), a developer tool that facilitates maintaining all of the HoloViz projects. See [Pixi](#Pixi) for more details.
-
-#### Contributing Changes
-
-After you have cloned the repo and set up Pixi, the next step is to create a branch and start making changes. Before committing these changes, make sure the tests still pass by running `pixi run test-unit` and that the code meets style guidelines by running `pixi run lint`. Once you are done with your changes, you can commit them. It is good practice to break down big changes into smaller chunks, and each chunk has its own commit with a message that summarizes it.
-
-#### Submitting Your Contribution
-
-Now you can push the branch to your clone and create a *pull request* from your clone to the original repository. This [Github Gist](https://gist.github.com/Chaser324/ce0505fbed06b947d962) describes these GitHub steps in more detail.
-
-The *pull request* you make should reference the *issue* you are attempting to close (i.e. `Fixes #issuenumber`) and include a description of the changes you made.
-See [linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) for more detailed instructions on how to do that. Changes affecting the visual properties should include screenshots or GIFs.
-
-Your *pull request* should now be reviewed by one of the project's maintainers. This may take a while given how busy the maintainers are, so try to be patient :). Your pull request will be evaluated to ensure that it is within the scope of the project (again, it's a good idea to create an issue first to outline your intent and give the maintainers an opportunity to weigh in before you spend the effort creating a pull request). If it's decided to proceed, the review will be conducted, and once the review is done you may be required to make some changes. You may also be asked to *resolve conflicts* if the changes you made appear to conflict with changes made to the source code after you submitted the *pull request*.
-
-When your PR is merged, enjoy, and repeat!
-
-# For Maintainers
-
 (operating-guide)=
-## Operating guide
+# Operating guide for maintainers
 
 The HoloViz project consists of:
 
@@ -139,15 +9,15 @@ The HoloViz project consists of:
 This section of the guide describes how that system works.
 
 
-### PyViz
+## PyViz
 
 The HoloViz project was previously named *PyViz* but the Python community suggested that it wasn't that appropriate and as such *PyViz* was renamed *HoloViz*, inspired by HoloViews. As renaming is a lot of work and can potentially break some systems, you will still find references to PyViz here and there. Notably, in the installation guide of each HoloViz package where the recommended installation command with conda is `conda install -c pyviz package`.
 
 *PyViz*, or [PyViz.org](https://pyviz.org/), is now a community project of its own. It is a fully open guide to all Python visualization tools. The HoloViz group maintains the [pyviz](https://github.com/pyviz) organization, but only for historical reasons, as it is meant to be shared by the whole Python visualization community.
 
-### GitHub/Git
+## GitHub/Git
 
-#### Organisations and repositories
+### Organisations and repositories
 
 HoloViz consists of several Python projects. All these projects are version-controlled with [Git](https://git-scm.com/) and hosted on GitHub. Having all the projects hosted on GitHub means that HoloViz can rely on all the excellent features Github freely provides to open-source projects, including easy collaboration through *Issues and Pull Requests (PR)*, continuous integration (CI) with *GitHub Actions (GHA)* and documentation hosting with *GitHub Pages*.
 
@@ -197,7 +67,7 @@ In more detail:
     * [holodoodler](https://github.com/holoviz-topics/holodoodler): Python application that allows interactive construction of sparse labeling for image segmentation using deep neural networks
     * more ...
 
-#### Teams
+### Teams
 
 The `HoloViz` organization has six teams:
 
@@ -208,14 +78,14 @@ The `HoloViz` organization has six teams:
 * [steering-committee](https://github.com/orgs/holoviz/teams/steering-committee): HoloViz Organization Steering Committee members
 * [Triaging team](https://github.com/orgs/holoviz/teams/triaging-team): Contributors able to triage open issues on HoloViz projects
 
-#### Service account
+### Service account
 
 The Github account [`holoviz-developers`](https://github.com/holoviz-developers) is a service account used for automated actions on HoloViz projects. For example, this account has a *Personal Access Token* with *repo* permission to:
 
 - Deploy development sites from one repository (e.g., holoviz/panel) to another (holoviz-dev/panel).
 - Allow the downstream tests workflow to trigger workflows in other repositories.
 
-#### Repository structure
+### Repository structure
 
 The core packages have their repository that, except in a few cases, all share the same structure:
 
@@ -225,7 +95,7 @@ The core packages have their repository that, except in a few cases, all share t
 * Optional: the `binder` directory contains configuration files to setup [binder](https://mybinder.org/)
 
 
-#### Git workflow
+### Git workflow
 
 The HoloViz projects follow the standard Github workflow:
 
@@ -234,9 +104,9 @@ The HoloViz projects follow the standard Github workflow:
 * *Pull requests* must be reviewed before being merged. Each project has one or more reviewer(s) assigned.
 * The commits of a *Pull request* are automatically [squashed on merge](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github#squashing-your-merge-commits). This means that you don't have to particularly well craft your commit messages in your branch as they won't be part of the main git history.
 
-### Tooling
+## Tooling
 
-#### Conda ecosystem
+### Conda ecosystem
 
 The HoloViz group relies heavily on the [conda ecosystem](https://conda.io/docs/intro.html) for the following reasons:
 
@@ -246,7 +116,8 @@ The HoloViz group relies heavily on the [conda ecosystem](https://conda.io/docs/
 
 To contribute to HoloViz, we **recommend** that you use the *conda ecosystem*. You would have a closer experience with the maintainers, and they will be in a better position to help you set up your dev environment and debug whatever issue you may encounter.
 
-#### Pixi
+(pixi-guide)=
+### Pixi
 
 [Pixi](https://pixi.sh/latest/) is a fast software package manager built on top of the conda ecosystem. It is used to simplify the management of the environments and tasks across projects.
 
@@ -264,9 +135,9 @@ Now that the main files are defined, we can go through each step of a typical wo
 * Choose a task to run, for example `pixi run test-unit` to run the unit tests. If multiple environments are available, you can specify the environment with the `--environment/-e` flag, e.g., `pixi run -e test-core test-unit`.
 * First time you run a task in an environment it will download and install packages into the `.pixi` directory.
 
-### Documentation
+## Documentation
 
-#### nbsite
+### nbsite
 
 Most of the packages maintained by the HoloViz group have a website. HoloViz being dedicated to making data visualization simpler in Python, it made sense for the group to develop a way to generate websites out of a collection of Jupyter Notebooks. As a result, [nbsite](https://github.com/holoviz-dev/nbsite) was created to achieve that goal. `nbsite` is based on [sphinx](https://www.sphinx-doc.org) and is the tool used by all the projects to build their site. `nbsite` provides two important features:
 
@@ -282,7 +153,7 @@ These steps can also be called with `pixi run docs-build`.
 
 After these steps, you should find a `builtdocs` folder in the repository that contains the static site built by nbsite/sphinx. When the websites are built in the continuous integration system, the content of the `builtdocs` folder is pushed to a `gh-pages` branch. The details of this process can be found in the `docs.yaml` Github Action workflow of each project, located in the `.github/workflows` folder.
 
-#### File formats
+### File formats
 
 The documentation is currently written in a mix of three file formats:
 
@@ -290,36 +161,36 @@ The documentation is currently written in a mix of three file formats:
 * *reStructuredText* (.rst): Original file format supported by Sphinx and in which the Python documentation is written. They should be gradually replaced by *MyST Markdown* files.
 * *Markdown* (.md):  [MyST Markdown](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html#syntax-core) is a Markdown extension focused on scientific and technical documentation authoring. It is easier to write and read compared to *reStructuredText*, which should be favored.
 
-#### Theme
+### Theme
 
 The HoloViz sites rely on the [PyData Sphinx Theme](https://pydata-sphinx-theme.readthedocs.io/) for their theme.
 
-#### Analytics
+### Analytics
 
 Data was previously collected using *Google Analytics*. However, starting in 2024, the HoloViz project transitioned to *GoatCounter* to better protect user privacy and comply with GDPR requirements.
 
 The data collected with *GoatCounter* is available at https://holoviz.goatcounter.com.
 
-#### Hosts
+### Hosts
 
 The HoloViz websites are usually hosted on *GitHub Pages*. The deployment process involves pushing the website built to the `gh-pages` branch, which is watched by GitHub and will trigger a site update on change. This process is based on Git and comes with some size limitations, which means that it wasn't possible to deploy HoloViews' website this way, which is instead hosted on AWS S3.
 
-#### Dev sites
+### Dev sites
 
 Most HoloViz projects have both the main site - the one meant to be visited by users and that is in line with the latest official release - and a dev site that can be updated at any time and is meant to be used by the HoloViz developers for testing purposes, and in particular making sure that the documentation build works as expected before making a new release.
 
 This page references all the HoloViz dev sites: https://holoviz-dev.github.io/. A link to the dev site is also usually available in the README file of each project.
 
-### Monitoring
+## Monitoring
 
-#### Status dashboard and scheduled workflows
+### Status dashboard and scheduled workflows
 
 The [HoloViz Status dashboard](https://status.holoviz.org/) is a site that lets you glance at the status of the packages and repositories maintained by the HoloViz group. It also includes the status of other packages important to HoloViz, e.g., Bokeh. The dashboard primarily consists of badges that report various indicators, such as the status of the latest CI test runs, the latest version available on PyPi, whether the documentation is up or not, etc.
 
 Scheduled Github actions have been set up to run on Sundays on most of the packages maintained by the group. This means that checking the *Status Dashboard* on a Monday morning is the right time to get an appreciation of the state of the test/build/docs workflows across the projects.
 
 
-#### Deployments
+### Deployments
 
 All the HoloViz websites are static websites. Yet many of their pages would actually require an active Python kernel to be fully interactive. I.e., any datashader examples on HoloViews' website would require a kernel to show users that data shading is done every time their plot changes. Some websites have implemented deployments to show users how the tools behave in a fully interactive environment. As the core HoloViz members are employed by Anaconda, they have access to an Anaconda product named [Enterprise Data Science Platform](https://www.anaconda.com/products/enterprise) (also called *AE5*) that is a platform to, among other things, allow to easily develop and deploy projects, like for instance Jupyter Notebooks or Panel apps. The HoloViz group has set up an AE5 instance and used it to deploy applications for the following websites:
 
@@ -327,7 +198,7 @@ All the HoloViz websites are static websites. Yet many of their pages would actu
 * [Examples](https://examples.holoviz.org/): this site offers users to run read-only Jupyter Notebooks and web apps like Panel apps (look for "*View a running version of this notebook.*" in the example header).
 
 
-#### Data Storage
+### Data Storage
 
 It is sometimes convenient to have a place where to store data. This happens when the data is too large to be stored on a GitHub repository (storing data there isn't recommended anyway), which is pretty standard when creating a tutorial that relies on an actual data set. The HoloViz group makes use of the following AWS S3 buckets:
 
@@ -337,7 +208,7 @@ It is sometimes convenient to have a place where to store data. This happens whe
 
 These buckets are managed by @jlstevens and @philippjfr.
 
-#### Domain names
+### Domain names
 
 Some of the sites have their own domain name:
 
@@ -353,7 +224,7 @@ While others are available as subdomains of holoviz.org:
 * [param.holoviz.org](https://param.holoviz.org)
 * [colorcet.holoviz.org](https://colorcet.holoviz.org)
 
-### Testing
+## Testing
 
 There are four main kinds of tests that a HoloViz project may run:
 
@@ -362,7 +233,7 @@ There are four main kinds of tests that a HoloViz project may run:
 * *Example tests*: the examples tests and the notebooks tests, in which the notebooks found in the `/examples` or `/doc` folder are all executed. Note that their output is not compared with any reference. Instead, the tests only fail if an error is raised while running the notebooks. The projects rely on pytest and [nbval](https://nbval.readthedocs.io). The `pixi run test-example` will run these tests.
 * *UI tests*: some projects may rely on [Playwright](https://playwright.dev/python/) and [pytest-playwright](https://github.com/microsoft/playwright-pytest) to run tests that check that things get displayed as expected in a browser and those interactions between the client and the backend work as expected. The `pixi run test-ui` command will run these tests.
 
-### Releasing
+## Releasing
 
 ```{attention}
 Releasing a new version of a package is an operation that needs to be done with care, a broken release can adversely affect many users.
@@ -372,7 +243,7 @@ Releasing a new version of a package is an operation that needs to be done with 
 Making a new release is a cumbersome and delicate operation. It implies many manual steps and has a cost on the general Python ecosystem, e.g., someone needs to update the *conda-forge* release. So make sure that a release is needed before making one, and try not to mess it up too badly ;)
 ```
 
-#### Quick intro
+### Quick intro
 
 Releasing a new package version is, in practice, very easy:
 
@@ -386,7 +257,7 @@ The two actions are split up into two jobs: `build` and `publish`. For the packa
 Version tags must start with a lowercase `v` and have a period in them, e.g., `v2.0`, `v0.9.8` or `v0.1` and may include the [PEP440](https://peps.python.org/pep-0440/) prerelease identifiers of `a` (alpha), `b` (beta) or `rc` (release candidate) allowing tags such as `v2.0.a3`, `v0.9.8.b3` or `v0.1.rc5`.
 ```
 
-#### Distributions
+### Distributions
 
 The goal of making a release is to distribute a new package version.
 
@@ -405,14 +276,14 @@ The core HoloViz packages are also made available on two other conda channels:
 Development releases are only available on PyPi and the conda `pyviz` channel. To install the latest development release, e.g., Panel execute `pip install panel --pre` or `conda install -c pyviz/label/dev panel`.
 ```
 
-#### Before releasing
+### Before releasing
 
 There are a few tasks that are worth paying attention to before making a release:
 * You should have made some decisions about what should go in that release and check later that these decided changes (bug fixes, new features, documentation, etc.) are indeed merged. This is best managed by setting Github *Milestones* to issues.
 * You should make sure that the test suite passes.
 * A new release is a good opportunity to check that **there are no alarming warnings** emitted while the tests suite runs. Missing a deprecation warning could mean that you would have to make a new release soon after this one!
 
-#### Detailed process
+### Detailed process
 
 Development releases can have different goals. Sometimes they are only meant to be pre-releases made right before an actual release to make sure everything is alright. Sometimes they are made to be shared with stakeholders (e.g., a specific contributor, a customer, a dependent project, etc.). Depending on your situation, you might decide to pause the release process in the procedure detailed below between two development releases, waiting for feedback.
 
@@ -456,17 +327,17 @@ You can tag a release from any branch, not necessarily from the main one. This i
 If you push a tag by mistake or the wrong tag and are lucky enough to spot that instantly, you should hurry up (really!) and [cancel](https://docs.github.com/en/actions/managing-workflow-runs/canceling-a-workflow) the *Build* and *Documentation* workflows before anything gets published/deployed. If you manage to do that, you can then remove the faulty tag.
 ```
 
-### Credentials
+## Credentials
 
 Shared credentials are stored in a 1Password vault. Get in touch with one of the owners to get access: @droumis, @philippjfr, and @maximlt.
 
-### Communication
+## Communication
 
-#### Users
+### Users
 
 **HoloViz Users** are meant to ask their questions on the [HoloViz Discourse forum](https://discourse.holoviz.org/). This Discourse instance is managed by @philippjfr.
 
-#### Contributors
+### Contributors
 
 **HoloViz Contributors** chat on multiple open channels:
 
@@ -475,13 +346,13 @@ Shared credentials are stored in a 1Password vault. Get in touch with one of the
 
 **HoloViz Contributors** also have regular online meetings. These meetings are **open to anyone**. Please see the [Community](https://holoviz.org/community.html) page for a calendar and description of the meetings.
 
-#### Outreach
+### Outreach
 
-##### Blogs
+#### Blogs
 
 The HoloViz project maintains a blog at https://blog.holoviz.org/ where new major releases are announced.
 
-##### Twitter
+#### Twitter
 
 There are four more or less active Twitter accounts:
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -66,7 +66,7 @@ Learn <learn/index>
 Tutorial <tutorial/index>
 Examples <https://examples.holoviz.org/>
 Community <community>
-Contribute <contribute>
+Contribute <contribute/index>
 Blog <https://blog.holoviz.org/>
 About <about/index>
 ```


### PR DESCRIPTION
Well overdue:
- One page for contributors
- One page for maintainers (the operating guide I wrote a while while back to help onboard new HoloViz members, quite outdated anyway)

<img width="1667" height="621" alt="image" src="https://github.com/user-attachments/assets/d8031f7c-7f75-4eb9-9fe1-e787e558be1d" />