### PR TITLE
Moved tutorial zip files into holoviz_tutorial subdirectory

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: git clean
         run: git clean -fxd .
       - name: zip tutorial
-        run: mv examples holoviz_tutorial && zip -r holoviz_tutorial3.zip holoviz_tutorial -x "holoviz_tutorial/data/*" ; mv holoviz_tutorial examples
+        run: mv examples holoviz_tutorial && zip -r holoviz_tutorial.zip holoviz_tutorial -x "holoviz_tutorial/data/*" ; mv holoviz_tutorial examples
       - name: save old
         env:
           FDATETIME: ${{ steps.vars.outputs.fdatetime }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: git clean
         run: git clean -fxd .
       - name: zip tutorial
-        run: cd examples && zip -r ../holoviz_tutorial.zip . -x "data/*"
+        run: mv examples holoviz_tutorial && zip -r holoviz_tutorial3.zip holoviz_tutorial -x "holoviz_tutorial/data/*" ; mv holoviz_tutorial examples
       - name: save old
         env:
           FDATETIME: ${{ steps.vars.outputs.fdatetime }}

--- a/examples/pixi.toml
+++ b/examples/pixi.toml
@@ -44,8 +44,6 @@ format = { cmd = "ruff format .", description = "Format code with ruff" }
 check = { cmd = "ruff check .", description = "Lint code with ruff" }
 clean_notebook = { cmd = "pre-commit run --all-files", description = "Run all pre-commit hooks" }
 
-
-
 [tasks]
 download-data = { cmd = """
 mkdir -p data/raster && \
@@ -57,7 +55,7 @@ curl -fsSL -o data/usgs_logo.png https://raw.githubusercontent.com/holoviz/holov
 """, outputs = ["data/"]}
 
 install = "pixi install"
-setup = { depends-on = ["install", "download-data", "lint-install"], description = "Set up the notebook environment." }
+setup = { depends-on = ["install", "download-data"], description = "Set up the notebook environment." }
 prepare = { depends-on = ["download-data"] }
 jupyter-lab = { cmd = "jupyter lab", depends-on = ["download-data"] }
 jupyter-notebook = { cmd = "jupyter notebook", depends-on = ["download-data"] }

--- a/examples/tutorial/00_Setup.ipynb
+++ b/examples/tutorial/00_Setup.ipynb
@@ -13,9 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This first step to the tutorial will ensure your system is set up to handle all the subsequent sections, with all software installed and all data downloaded as needed. The [index](index.ipynb) provides some links you might want to examine before you start.\n",
-    "\n",
-    "If you are using an AI assistant while learning, building, or preparing to contribute to HoloViz, [holoviz-skills](https://holoviz-dev.github.io/holoviz-skills/) is a useful companion for HoloViz-specific guidance. It is a curated set of instructions and references that helps AI tools produce more idiomatic HoloViz examples and advice across the ecosystem. The most relevant entry point for this tutorial is the `developing-with-holoviz` directory, which routes to the right guidance for `hvplot`, `holoviews`, `panel`, and `param` depending on what you are working on."
+    "This first step to the tutorial will ensure your system is set up to handle all the subsequent sections, with all software installed and all data downloaded as needed. The [index](index.ipynb) provides some links you might want to examine before you start."
    ]
   },
   {
@@ -42,27 +40,30 @@
    "source": [
     "## Getting set up\n",
     "\n",
-    "1. **Install pixi**:\n",
-    "   If you don't have pixi installed, you can follow the [pixi docs](https://pixi.prefix.dev/latest/installation/) to download and install it.\n",
+    "1. **Open a new terminal window**:\n",
+    "   (e.g. Terminal on a Mac, Powershell on Windows, or XTerm on Linux)\n",
     "\n",
+    "2. **Install pixi**:\n",
+    "   If you don't have the pixi package manager installed, you can follow the [pixi docs](https://pixi.prefix.dev/latest/installation/) to download and install it.\n",
     "\n",
-    "2. **Download and navigate to the tutorial project**: Download the tutorial ZIP archive from https://assets.holoviz.org/holoviz/tutorial/holoviz_tutorial.zip, unzip it and go to the `holoviz_tutorial` directory.\n",
+    "3. **Download and navigate to the tutorial project**:\n",
+    "    - Download the [tutorial ZIP archive](https://assets.holoviz.org/holoviz/tutorial/holoviz_tutorial.zip)\n",
+    "    - unzip it\n",
+    "    - change to the unzipped `holoviz_tutorial` directory.\n",
     "\n",
-    "3. **Open a new terminal window**\n",
-    "\n",
-    "4. **Create and activate a new pixi environment**: This environment is just for `pixi`, a tool to help download the required packages and data for the tutorial.\n",
+    "4. **Create and activate the tutorial environment**:\n",
     "    ```bash\n",
     "    pixi run setup\n",
     "    ```\n",
     "\n",
-    "5. **Launch Jupyter**: Don't be alarmed when this command outputs many lines as it downloads packages before launching Jupyter. Subsequent launches will be faster as the downloaded data is cached.\n",
+    "5. **Launch Jupyter**: Don't be alarmed when the previous command or this one outputs many lines as it downloads and installs packages. Subsequent launches will be faster as the downloaded packages are cached.\n",
     "    ```bash\n",
     "    pixi run jupyter-lab\n",
     "    ```\n",
     "    Note: You can replace \"lab\" with \"notebook\" if you prefer the original Jupyter notebook interface.\n",
     "\n",
     "6. **Test HoloViz imports**:\n",
-    "After launching Jupyter, navigate to this notebook (`tutorial/00_Setup.ipynb`) and run the following cell. This command is a quick check that your environment is set up correctly. You should see the HoloViews, Bokeh, and Matplotlib logos along with a success message.\n"
+    "After launching Jupyter, navigate to this notebook (`tutorial/00_Setup.ipynb`) and run the following cell. This command is a quick check that your environment is set up correctly. You should see the HoloViews, Bokeh, and Matplotlib logos along with a success message like `All specified packages are correctly installed`.\n"
    ]
   },
   {
@@ -102,7 +103,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you don't see any error messages above, you should be good to go!  Now that you are set up, you can continue with the [rest of the tutorial sections](01_Overview.ipynb). "
+    "If you see `Data exists and is readable!` and no error messages above, you should be good to go!  Now that you are set up, you can continue with the [rest of the tutorial sections](01_Overview.ipynb). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{hint}\n",
+    "If you are using an AI assistant while learning, building, or preparing to contribute to HoloViz, you should also consider installing [holoviz-skills](https://holoviz-dev.github.io/holoviz-skills/), which provides the AI tool with HoloViz-specific guidance. holoviz-skills is a curated set of instructions and references that helps AI tools produce more idiomatic HoloViz examples and advice across the ecosystem. The most relevant entry point for this tutorial is the `developing-with-holoviz` directory, which routes to the right guidance for `hvplot`, `holoviews`, `panel`, and `param` depending on what you are working on.\n",
+    "```"
    ]
   }
  ],


### PR DESCRIPTION
Moved tutorial zip files into holoviz_tutorial subdirectory for isolation from homedir. 

With the previous version, when I unpacked it into my home directory, pixi was recursively scanning the many thousands of files in my homedir and reporting a bunch of irrelevant issues like dangling symlinks. 

Updated the Setup docs to match.